### PR TITLE
fix(logging): Improve type safety for VSCode API injection

### DIFF
--- a/src/services/logging.ts
+++ b/src/services/logging.ts
@@ -16,7 +16,7 @@ let vscodeApi: typeof vscode = vscode;
  * 設置 VSCode API 引用（僅用於測試）
  * @param api VSCode API 實例
  */
-export function _setVSCodeApi(api: any): void {
+export function _setVSCodeApi(api: typeof vscode): void {
 	vscodeApi = api;
 	// 重置 output channel，以便使用新的 API
 	outputChannel = undefined;
@@ -25,7 +25,7 @@ export function _setVSCodeApi(api: any): void {
 /**
  * 獲取當前的 output channel（僅用於測試）
  */
-export function _getOutputChannel(): any {
+export function _getOutputChannel(): vscode.LogOutputChannel | undefined {
 	return outputChannel;
 }
 


### PR DESCRIPTION
## 📋 修正摘要 | Fix Summary

修正 `logging.ts` 中的型別安全問題，將測試用的 API 注入函數從 `any` 改為明確型別。

Improves type safety in `logging.ts` by replacing `any` types with explicit types for test API injection functions.

---

## 🔧 變更內容 | Changes

### Type Safety Improvements

**Before**:
```typescript
export function _setVSCodeApi(api: any): void
export function _getOutputChannel(): any
```

**After**:
```typescript
export function _setVSCodeApi(api: typeof vscode): void
export function _getOutputChannel(): vscode.LogOutputChannel | undefined
```

---

## 🎯 解決的問題 | Problem Solved

- ✅ **Type Safety**: 消除 `any` 型別，提升 TypeScript 型別檢查
- ✅ **Code Quality**: 符合 PR #7 Copilot Review 建議 #4
- ✅ **Test Reliability**: 測試環境的 API mock 更加型別安全

---

## ✅ 測試結果 | Test Results

- **編譯**: ✅ Webpack compiled successfully
- **型別檢查**: ✅ No TypeScript errors
- **單元測試**: ✅ Logging tests passing (無迴歸)

---

## 📚 相關連結 | Related Links

- **來源**: PR #7 Copilot Review Comment #4
- **Review URL**: https://github.com/Shen-Ming-Hong/singular-blockly/pull/7#discussion_r2441912393

---

## 🏷️ 標籤 | Labels

- Type: `hotfix` 🔥
- Priority: `low` (code quality improvement)
- Impact: `minimal` (測試環境限定)

---

_This hotfix addresses type safety concerns raised in automated code review while maintaining 100% backward compatibility._