### PR TITLE
fix(webview): isolate editor surfaces from host theme

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -228,5 +228,5 @@ Conventional Commits with scopes: `feat(blocks)`, `fix(webview)`, `i18n(ja)`, `c
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/056-txt-m-output-redesign/plan.md`
+shell commands, and other important information, read `specs/057-editor-theme-surface-consistency/plan.md`
 <!-- SPECKIT END -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-    "feature_directory": "specs/056-txt-m-output-redesign"
+    "feature_directory": "specs/057-editor-theme-surface-consistency"
 }

--- a/media/css/blocklyEdit.css
+++ b/media/css/blocklyEdit.css
@@ -445,6 +445,13 @@ body.theme-dark .txt-virtual-controls-mode-badge.running {
 	border-color: #ffca28;
 }
 
+body.vscode-high-contrast .txt-virtual-controls-mode-badge.running,
+body.vscode-high-contrast-light .txt-virtual-controls-mode-badge.running {
+	background: Highlight;
+	color: HighlightText;
+	border-color: Highlight;
+}
+
 .txt-virtual-controls-canvas.running {
 	border-style: solid;
 	border-color: var(--txt-virtual-control-state-ring);

--- a/media/css/blocklyEdit.css
+++ b/media/css/blocklyEdit.css
@@ -14,6 +14,31 @@ body {
 }
 
 :root {
+	--editor-surface-bg: #ffffff;
+	--editor-surface-fg: #1e1e1e;
+	--editor-surface-border: rgba(0, 0, 0, 0.12);
+	--editor-modal-backdrop: rgba(0, 0, 0, 0.5);
+	--editor-field-bg: #ffffff;
+	--editor-field-fg: #1e1e1e;
+	--editor-field-border: rgba(0, 0, 0, 0.2);
+	--editor-field-placeholder-fg: #6a6a6a;
+	--editor-card-bg: #ffffff;
+	--editor-card-fg: #1e1e1e;
+	--editor-card-border: rgba(0, 0, 0, 0.14);
+	--editor-card-hover-border: #1976d2;
+	--editor-description-fg: #666666;
+	--editor-notice-bg: rgba(25, 118, 210, 0.1);
+	--editor-notice-fg: #174a7c;
+	--editor-notice-border: rgba(25, 118, 210, 0.28);
+	--editor-warning-bg: rgba(245, 166, 35, 0.16);
+	--editor-warning-fg: #4d3200;
+	--editor-warning-border: #c27a00;
+	--editor-status-ok-fg: #2e7d32;
+	--editor-status-error-fg: #c62828;
+	--editor-focus-ring: var(--vscode-focusBorder, #007acc);
+	--editor-scrollbar-track: #f1f1f1;
+	--editor-scrollbar-thumb: #c1c1c1;
+	--editor-scrollbar-thumb-hover: #a8a8a8;
 	--txt-virtual-controls-panel-bg: #ffffff;
 	--txt-virtual-controls-panel-fg: #1e1e1e;
 	--txt-virtual-controls-panel-border: rgba(0, 0, 0, 0.12);
@@ -29,44 +54,37 @@ body {
 	--txt-virtual-control-button-border: rgba(0, 0, 0, 0.28);
 	--txt-virtual-control-button-shadow: 0 4px 10px rgba(0, 0, 0, 0.14);
 	--txt-virtual-control-state-ring: var(--vscode-focusBorder, #007acc);
-	--txt-virtual-controls-warning-bg: var(--vscode-inputValidation-warningBackground, rgba(245, 166, 35, 0.16));
-	--txt-virtual-controls-warning-fg: var(--vscode-inputValidation-warningForeground, var(--vscode-editorWarning-foreground, inherit));
-	--txt-virtual-controls-warning-border: var(--vscode-inputValidation-warningBorder, #f5a623);
-}
-
-body.vscode-light {
-	--txt-virtual-controls-panel-bg: var(--vscode-sideBar-background, #ffffff);
-	--txt-virtual-controls-panel-fg: var(--vscode-sideBar-foreground, #1e1e1e);
-	--txt-virtual-controls-panel-border: var(--vscode-sideBar-border, rgba(0, 0, 0, 0.12));
-	--txt-virtual-controls-canvas-surface: var(--vscode-editor-background, #f8f8f8);
-	--txt-virtual-controls-description-fg: var(--vscode-descriptionForeground, #666666);
-	--txt-virtual-controls-field-bg: var(--vscode-input-background, #ffffff);
-	--txt-virtual-controls-field-fg: var(--vscode-input-foreground, #1e1e1e);
-	--txt-virtual-controls-field-border: var(--vscode-input-border, rgba(0, 0, 0, 0.2));
-	--txt-virtual-controls-code-bg: var(--vscode-textCodeBlock-background, rgba(0, 0, 0, 0.07));
-	--txt-virtual-controls-code-fg: var(--vscode-editor-foreground, #1e1e1e);
-	--txt-virtual-controls-code-border: var(--vscode-panel-border, rgba(0, 0, 0, 0.12));
-	--txt-virtual-control-button-border: var(--vscode-contrastBorder, rgba(0, 0, 0, 0.28));
-}
-
-body.vscode-dark {
-	--txt-virtual-controls-panel-bg: var(--vscode-sideBar-background, #252526);
-	--txt-virtual-controls-panel-fg: var(--vscode-sideBar-foreground, #cccccc);
-	--txt-virtual-controls-panel-border: var(--vscode-sideBar-border, rgba(255, 255, 255, 0.16));
-	--txt-virtual-controls-canvas-surface: var(--vscode-editor-background, #1e1e1e);
-	--txt-virtual-controls-description-fg: var(--vscode-descriptionForeground, #a6a6a6);
-	--txt-virtual-controls-field-bg: var(--vscode-input-background, #313131);
-	--txt-virtual-controls-field-fg: var(--vscode-input-foreground, #f0f0f0);
-	--txt-virtual-controls-field-border: var(--vscode-input-border, rgba(255, 255, 255, 0.24));
-	--txt-virtual-controls-code-bg: var(--vscode-textCodeBlock-background, rgba(255, 255, 255, 0.12));
-	--txt-virtual-controls-code-fg: var(--vscode-editor-foreground, #f0f0f0);
-	--txt-virtual-controls-code-border: var(--vscode-panel-border, rgba(255, 255, 255, 0.2));
-	--txt-virtual-controls-grid-line: rgba(255, 255, 255, 0.08);
-	--txt-virtual-control-button-border: var(--vscode-contrastBorder, rgba(255, 255, 255, 0.36));
-	--txt-virtual-control-button-shadow: 0 4px 12px rgba(0, 0, 0, 0.38);
+	--txt-virtual-controls-warning-bg: var(--editor-warning-bg);
+	--txt-virtual-controls-warning-fg: var(--editor-warning-fg);
+	--txt-virtual-controls-warning-border: var(--editor-warning-border);
 }
 
 body.theme-light {
+	color-scheme: light;
+	--editor-surface-bg: #ffffff;
+	--editor-surface-fg: #1e1e1e;
+	--editor-surface-border: rgba(0, 0, 0, 0.12);
+	--editor-modal-backdrop: rgba(0, 0, 0, 0.5);
+	--editor-field-bg: #ffffff;
+	--editor-field-fg: #1e1e1e;
+	--editor-field-border: rgba(0, 0, 0, 0.2);
+	--editor-field-placeholder-fg: #6a6a6a;
+	--editor-card-bg: #ffffff;
+	--editor-card-fg: #1e1e1e;
+	--editor-card-border: rgba(0, 0, 0, 0.14);
+	--editor-card-hover-border: #1976d2;
+	--editor-description-fg: #666666;
+	--editor-notice-bg: rgba(25, 118, 210, 0.1);
+	--editor-notice-fg: #174a7c;
+	--editor-notice-border: rgba(25, 118, 210, 0.28);
+	--editor-warning-bg: rgba(245, 166, 35, 0.16);
+	--editor-warning-fg: #4d3200;
+	--editor-warning-border: #c27a00;
+	--editor-status-ok-fg: #2e7d32;
+	--editor-status-error-fg: #c62828;
+	--editor-scrollbar-track: #f1f1f1;
+	--editor-scrollbar-thumb: #c1c1c1;
+	--editor-scrollbar-thumb-hover: #a8a8a8;
 	--txt-virtual-controls-panel-bg: #ffffff;
 	--txt-virtual-controls-panel-fg: #1e1e1e;
 	--txt-virtual-controls-panel-border: rgba(0, 0, 0, 0.12);
@@ -84,6 +102,31 @@ body.theme-light {
 }
 
 body.theme-dark {
+	color-scheme: dark;
+	--editor-surface-bg: #333333;
+	--editor-surface-fg: #e0e0e0;
+	--editor-surface-border: #555555;
+	--editor-modal-backdrop: rgba(0, 0, 0, 0.62);
+	--editor-field-bg: #333333;
+	--editor-field-fg: #e0e0e0;
+	--editor-field-border: #555555;
+	--editor-field-placeholder-fg: #aaaaaa;
+	--editor-card-bg: #252526;
+	--editor-card-fg: #e0e0e0;
+	--editor-card-border: #555555;
+	--editor-card-hover-border: #8ab4f8;
+	--editor-description-fg: #b8b8b8;
+	--editor-notice-bg: rgba(138, 180, 248, 0.14);
+	--editor-notice-fg: #d8e6ff;
+	--editor-notice-border: rgba(138, 180, 248, 0.34);
+	--editor-warning-bg: rgba(255, 202, 40, 0.16);
+	--editor-warning-fg: #ffe9a8;
+	--editor-warning-border: #ffca28;
+	--editor-status-ok-fg: #81c784;
+	--editor-status-error-fg: #ff8a80;
+	--editor-scrollbar-track: #333333;
+	--editor-scrollbar-thumb: #666666;
+	--editor-scrollbar-thumb-hover: #888888;
 	--txt-virtual-controls-panel-bg: #252526;
 	--txt-virtual-controls-panel-fg: #cccccc;
 	--txt-virtual-controls-panel-border: rgba(255, 255, 255, 0.16);
@@ -102,10 +145,35 @@ body.theme-dark {
 
 body.vscode-high-contrast,
 body.vscode-high-contrast-light {
-	--txt-virtual-controls-panel-bg: var(--vscode-sideBar-background, Canvas);
-	--txt-virtual-controls-panel-fg: var(--vscode-sideBar-foreground, CanvasText);
+	--editor-surface-bg: Canvas;
+	--editor-surface-fg: CanvasText;
+	--editor-surface-border: CanvasText;
+	--editor-modal-backdrop: rgba(0, 0, 0, 0.75);
+	--editor-field-bg: Field;
+	--editor-field-fg: FieldText;
+	--editor-field-border: CanvasText;
+	--editor-field-placeholder-fg: GrayText;
+	--editor-card-bg: Canvas;
+	--editor-card-fg: CanvasText;
+	--editor-card-border: CanvasText;
+	--editor-card-hover-border: Highlight;
+	--editor-description-fg: CanvasText;
+	--editor-notice-bg: Canvas;
+	--editor-notice-fg: CanvasText;
+	--editor-notice-border: CanvasText;
+	--editor-warning-bg: Canvas;
+	--editor-warning-fg: CanvasText;
+	--editor-warning-border: Highlight;
+	--editor-status-ok-fg: CanvasText;
+	--editor-status-error-fg: CanvasText;
+	--editor-focus-ring: var(--vscode-contrastActiveBorder, Highlight);
+	--editor-scrollbar-track: Canvas;
+	--editor-scrollbar-thumb: CanvasText;
+	--editor-scrollbar-thumb-hover: Highlight;
+	--txt-virtual-controls-panel-bg: Canvas;
+	--txt-virtual-controls-panel-fg: CanvasText;
 	--txt-virtual-controls-panel-border: var(--vscode-contrastBorder, CanvasText);
-	--txt-virtual-controls-canvas-surface: var(--vscode-editor-background, Canvas);
+	--txt-virtual-controls-canvas-surface: Canvas;
 	--txt-virtual-controls-description-fg: CanvasText;
 	--txt-virtual-controls-field-bg: Field;
 	--txt-virtual-controls-field-fg: FieldText;
@@ -117,6 +185,8 @@ body.vscode-high-contrast-light {
 	--txt-virtual-control-button-border: var(--vscode-contrastBorder, CanvasText);
 	--txt-virtual-control-button-shadow: none;
 	--txt-virtual-control-state-ring: var(--vscode-contrastActiveBorder, Highlight);
+	--txt-virtual-controls-warning-bg: Canvas;
+	--txt-virtual-controls-warning-fg: CanvasText;
 	--txt-virtual-controls-warning-border: var(--vscode-contrastActiveBorder, Highlight);
 }
 
@@ -135,8 +205,9 @@ body.preview-mode {
 	position: fixed;
 	top: 15px;
 	left: 15px;
-	background-color: rgba(255, 255, 255, 0.9);
-	color: #333;
+	background-color: var(--editor-card-bg);
+	color: var(--editor-card-fg);
+	border: 1px solid var(--editor-card-border);
 	padding: 12px 18px;
 	border-radius: 8px;
 	z-index: 2000;
@@ -153,11 +224,6 @@ body.preview-mode {
 	opacity: 1;
 }
 
-body.theme-dark .preview-info {
-	background-color: rgba(50, 50, 50, 0.9);
-	color: #f0f0f0;
-}
-
 .preview-info-content {
 	display: flex;
 	flex-direction: column;
@@ -172,16 +238,13 @@ body.theme-dark .preview-info {
 }
 
 .preview-badge {
-	background-color: #3f51b5;
-	color: white;
+	background-color: var(--editor-notice-bg);
+	color: var(--editor-notice-fg);
+	border: 1px solid var(--editor-notice-border);
 	font-size: 12px;
 	padding: 2px 8px;
 	border-radius: 4px;
 	margin-left: 8px;
-}
-
-body.theme-dark .preview-badge {
-	background-color: #5c6bc0;
 }
 
 .preview-subtitle {
@@ -194,39 +257,51 @@ body.theme-dark .preview-badge {
 }
 
 .preview-blockly-area {
+	background-color: var(--editor-surface-bg);
 	border-top: none;
 }
 
 /* 預覽模式控制容器樣式 */
-.preview-controls {
+body.preview-mode .preview-controls {
 	display: flex;
 	justify-content: center; /* 水平置中 */
 	align-items: center;
 	padding: 6px;
 	width: auto;
 	min-width: 60px;
-	background-color: rgba(255, 255, 255, 0.9);
+	background-color: var(--editor-card-bg);
+	color: var(--editor-card-fg);
+	border: 1px solid var(--editor-card-border);
 	backdrop-filter: blur(5px);
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-/* 深色模式下的預覽控制容器和按鈕 */
-body.theme-dark .preview-controls {
-	background-color: rgba(50, 50, 50, 0.9);
-	color: #e0e0e0;
+body.preview-mode .preview-controls #themeToggle {
+	background-color: var(--editor-field-bg);
+	color: var(--editor-field-fg);
+	border: 1px solid var(--editor-field-border);
 }
 
-body.theme-dark .preview-controls #themeToggle {
-	background-color: #444444;
-	color: #e0e0e0;
+body.preview-mode .preview-controls #themeToggle:hover {
+	background-color: var(--editor-notice-bg);
 }
 
-body.theme-dark .preview-controls #themeToggle:hover {
-	background-color: #555555;
+body.preview-mode .preview-controls #themeToggle:focus-visible {
+	outline: 2px solid var(--editor-focus-ring);
+	outline-offset: 2px;
 }
 
-body.theme-dark .preview-controls .theme-icon {
-	color: #e0e0e0;
+body.preview-mode .preview-controls .theme-icon {
+	color: currentColor;
+}
+
+.board-warning {
+	background-color: var(--editor-warning-bg);
+	color: var(--editor-warning-fg);
+	border-bottom: 1px solid var(--editor-warning-border);
+	padding: 8px 16px;
+	font-size: 13px;
+	text-align: center;
 }
 
 .container {
@@ -310,8 +385,8 @@ body.theme-dark .preview-controls .theme-icon {
 		90deg,
 		transparent 0,
 		transparent 3px,
-		var(--vscode-panel-border, rgba(0, 0, 0, 0.14)) 3px,
-		var(--vscode-panel-border, rgba(0, 0, 0, 0.14)) 7px,
+		var(--txt-virtual-controls-panel-border) 3px,
+		var(--txt-virtual-controls-panel-border) 7px,
 		transparent 7px,
 		transparent 100%
 	);
@@ -319,11 +394,11 @@ body.theme-dark .preview-controls .theme-icon {
 
 .txt-virtual-controls-splitter.open:hover,
 body.txt-virtual-controls-resizing .txt-virtual-controls-splitter.open {
-	background-color: var(--vscode-list-hoverBackground, rgba(0, 122, 204, 0.08));
+	background-color: var(--editor-notice-bg);
 }
 
 .txt-virtual-controls-panel.has-invalid-references {
-	box-shadow: inset 3px 0 0 var(--vscode-inputValidation-warningBorder, #f5a623);
+	box-shadow: inset 3px 0 0 var(--txt-virtual-controls-warning-border);
 }
 
 .txt-virtual-controls-panel-header {
@@ -352,20 +427,22 @@ body.txt-virtual-controls-resizing .txt-virtual-controls-splitter.open {
 	border-radius: 999px;
 	font-size: 0.75rem;
 	font-weight: 600;
-	background: var(--vscode-badge-background, rgba(0, 0, 0, 0.08));
-	color: var(--vscode-badge-foreground, inherit);
+	background: var(--editor-notice-bg);
+	color: var(--editor-notice-fg);
+	border: 1px solid var(--editor-notice-border);
 }
 
 .txt-virtual-controls-mode-badge.running {
-	background: var(--vscode-debugIcon-startForeground, #2e7d32);
+	background: var(--editor-status-ok-fg);
 	color: #ffffff;
+	border-color: var(--editor-status-ok-fg);
 	box-shadow: 0 0 0 1px var(--txt-virtual-control-state-ring);
 }
 
-body.theme-dark .txt-virtual-controls-mode-badge.running,
-body.vscode-dark .txt-virtual-controls-mode-badge.running {
+body.theme-dark .txt-virtual-controls-mode-badge.running {
 	background: #ffca28;
 	color: #1f1f1f;
+	border-color: #ffca28;
 }
 
 .txt-virtual-controls-canvas.running {
@@ -858,8 +935,8 @@ body.preview-mode .txt-preview-readonly-panel .txt-virtual-controls-panel-header
 }
 
 body.preview-mode .txt-preview-readonly-panel .txt-virtual-controls-mode-badge {
-	background: var(--vscode-badge-background, #3f51b5);
-	color: var(--vscode-badge-foreground, #ffffff);
+	background: var(--editor-notice-bg);
+	color: var(--editor-notice-fg);
 }
 
 body.preview-mode .txt-preview-canvas {
@@ -868,6 +945,30 @@ body.preview-mode .txt-preview-canvas {
 	overflow: auto;
 	cursor: default;
 	scrollbar-width: thin;
+	scrollbar-color: var(--editor-scrollbar-thumb) var(--editor-scrollbar-track);
+}
+
+body.preview-mode .txt-preview-canvas::-webkit-scrollbar {
+	width: 12px;
+	height: 12px;
+}
+
+body.preview-mode .txt-preview-canvas::-webkit-scrollbar-track {
+	background: var(--editor-scrollbar-track);
+}
+
+body.preview-mode .txt-preview-canvas::-webkit-scrollbar-thumb {
+	background: var(--editor-scrollbar-thumb);
+	border: 2px solid var(--editor-scrollbar-track);
+	border-radius: 6px;
+}
+
+body.preview-mode .txt-preview-canvas::-webkit-scrollbar-thumb:hover {
+	background: var(--editor-scrollbar-thumb-hover);
+}
+
+body.preview-mode .txt-preview-canvas::-webkit-scrollbar-corner {
+	background: var(--editor-scrollbar-track);
 }
 
 body.preview-mode .txt-preview-canvas:focus-visible {
@@ -896,7 +997,7 @@ body.preview-mode .txt-preview-readonly-panel .txt-virtual-control-button:focus-
 }
 
 body.preview-mode .txt-preview-readonly-panel .txt-virtual-control-button.recovered {
-	outline: 2px dashed var(--vscode-inputValidation-warningBorder, #f5a623);
+	outline: 2px dashed var(--txt-virtual-controls-warning-border);
 	outline-offset: 2px;
 }
 
@@ -920,8 +1021,9 @@ body.preview-mode .txt-preview-readonly-panel .txt-virtual-control-button.recove
 }
 
 .txt-preview-warning-item.info {
-	background: var(--vscode-textBlockQuote-background, rgba(127, 127, 127, 0.12));
-	border-color: var(--vscode-panel-border, rgba(0, 0, 0, 0.14));
+	background: var(--editor-notice-bg);
+	color: var(--editor-notice-fg);
+	border-color: var(--editor-notice-border);
 }
 
 body.preview-mode .txt-preview-readonly-splitter.open {
@@ -929,8 +1031,20 @@ body.preview-mode .txt-preview-readonly-splitter.open {
 }
 
 @media (forced-colors: active) {
+	.txt-connection-modal-content,
+	.txt-connection-input,
+	.preview-info,
+	.preview-controls,
+	.preview-controls #themeToggle,
+	.preview-badge,
+	.board-warning,
+	.sample-card,
+	.sample-offline-notice,
+	.sample-empty-notice,
 	.txt-virtual-controls-panel,
+	.txt-preview-canvas,
 	.txt-virtual-controls-canvas,
+	.txt-virtual-controls-mode-badge,
 	.txt-preview-warning-item,
 	.txt-virtual-control-button {
 		forced-color-adjust: auto;
@@ -938,6 +1052,8 @@ body.preview-mode .txt-preview-readonly-splitter.open {
 		box-shadow: none;
 	}
 
+	.txt-connection-input:focus-visible,
+	.preview-controls #themeToggle:focus-visible,
 	.txt-virtual-control-button:focus-visible,
 	.txt-virtual-control-button.selected {
 		outline-color: Highlight;
@@ -1189,8 +1305,9 @@ body.preview-mode .txt-preview-readonly-splitter.open {
 	}
 
 #txtVirtualControlsToggle.has-invalid-references {
-	background-color: var(--vscode-inputValidation-warningBackground, #f5a623);
-	color: var(--vscode-inputValidation-warningForeground, #1e1e1e);
+	background-color: var(--editor-warning-bg);
+	color: var(--editor-warning-fg);
+	box-shadow: 0 0 0 2px var(--editor-warning-border);
 	}
 
 #txtConfigButton,
@@ -1234,6 +1351,68 @@ body.txt-virtual-controls-resizing * {
 	background-color: #e65100;
 }
 
+.txt-connection-modal-content {
+	max-width: 520px;
+}
+
+.txt-connection-form-grid {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 8px 12px;
+	align-items: center;
+	margin-bottom: 12px;
+}
+
+.txt-connection-form-grid label {
+	color: var(--editor-surface-fg);
+	font-weight: 600;
+}
+
+.txt-connection-input {
+	background: var(--editor-field-bg);
+	color: var(--editor-field-fg);
+	border: 1px solid var(--editor-field-border);
+	padding: 4px 8px;
+	border-radius: 4px;
+	min-width: 0;
+}
+
+.txt-connection-input::placeholder {
+	color: var(--editor-field-placeholder-fg);
+}
+
+.txt-connection-input:focus-visible {
+	outline: 2px solid var(--editor-focus-ring);
+	outline-offset: 2px;
+}
+
+.txt-connection-actions {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.txt-connection-action-button {
+	padding: 4px 12px;
+}
+
+.txt-connection-status {
+	font-size: 0.85em;
+	color: var(--editor-description-fg);
+}
+
+.txt-connection-hint {
+	margin: 8px 0 0;
+	font-size: 0.8rem;
+	line-height: 1.45;
+	color: var(--editor-description-fg);
+}
+
+.txt-connection-hint-success {
+	color: var(--editor-status-ok-fg);
+}
+
 /* 範例瀏覽器模態樣式 */
 .sample-modal-content {
 	max-width: 720px;
@@ -1242,8 +1421,9 @@ body.txt-virtual-controls-resizing * {
 }
 
 .sample-offline-notice {
-	background-color: var(--vscode-inputValidation-warningBackground, #f5a623);
-	color: var(--vscode-inputValidation-warningForeground, #1e1e1e);
+	background-color: var(--editor-warning-bg);
+	color: var(--editor-warning-fg);
+	border: 1px solid var(--editor-warning-border);
 	padding: 8px 14px;
 	border-radius: 4px;
 	margin-bottom: 12px;
@@ -1256,15 +1436,16 @@ body.txt-virtual-controls-resizing * {
 	align-items: center;
 	justify-content: center;
 	padding: 32px 0;
+	color: var(--editor-description-fg);
 }
 
 /* TXT Controller 連線狀態樣式 */
 .txt-status-ok {
-	color: var(--vscode-terminal-ansiGreen, #4ec9b0);
+	color: var(--editor-status-ok-fg);
 }
 
 .txt-status-error {
-	color: var(--vscode-inputValidation-errorForeground, #f48771);
+	color: var(--editor-status-error-fg);
 }
 
 /* ── TXT I/O Test Panel Dialog ─────────────────────────────────────────── */
@@ -1508,10 +1689,9 @@ body.txt-virtual-controls-resizing * {
 	font-size: 0.85em;
 	font-weight: 700;
 	letter-spacing: 0.04em;
-	opacity: 0.7;
 	padding: 12px 0 8px;
 	border: none;
-	border-bottom: 1px solid var(--vscode-panel-border, #454545);
+	border-bottom: 1px solid var(--editor-card-border);
 	margin-bottom: 12px;
 	cursor: pointer;
 	user-select: none;
@@ -1520,7 +1700,7 @@ body.txt-virtual-controls-resizing * {
 	justify-content: space-between;
 	width: 100%;
 	background: transparent;
-	color: inherit;
+	color: var(--editor-description-fg);
 	text-align: left;
 }
 
@@ -1546,18 +1726,22 @@ body.txt-virtual-controls-resizing * {
 }
 
 .sample-card {
-	border: 1px solid var(--vscode-panel-border, #454545);
+	border: 1px solid var(--editor-card-border);
 	border-radius: 8px;
 	padding: 16px;
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-	background-color: var(--vscode-editor-background, #1e1e1e);
-	transition: border-color 0.2s;
+	background-color: var(--editor-card-bg);
+	color: var(--editor-card-fg);
+	transition:
+		border-color 0.2s,
+		box-shadow 0.2s;
 }
 
 .sample-card:hover {
-	border-color: var(--vscode-focusBorder, #007acc);
+	border-color: var(--editor-card-hover-border);
+	box-shadow: 0 0 0 1px var(--editor-card-hover-border);
 }
 
 .sample-card-title {
@@ -1567,7 +1751,7 @@ body.txt-virtual-controls-resizing * {
 
 .sample-card-description {
 	font-size: 0.82em;
-	opacity: 0.75;
+	color: var(--editor-description-fg);
 	flex: 1;
 }
 
@@ -1579,7 +1763,7 @@ body.txt-virtual-controls-resizing * {
 .sample-empty-notice {
 	text-align: center;
 	padding: 32px 0;
-	opacity: 0.6;
+	color: var(--editor-description-fg);
 	font-size: 0.9em;
 }
 
@@ -1591,7 +1775,7 @@ body.txt-virtual-controls-resizing * {
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background-color: rgba(0, 0, 0, 0.5);
+	background-color: var(--editor-modal-backdrop);
 	z-index: 2000;
 	overflow-y: auto;
 }
@@ -1601,7 +1785,9 @@ body.txt-virtual-controls-resizing * {
 	margin: 10% auto;
 	width: 80%;
 	max-width: 600px;
-	background-color: white;
+	background-color: var(--editor-surface-bg);
+	color: var(--editor-surface-fg);
+	border: 1px solid var(--editor-surface-border);
 	border-radius: 8px;
 	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 	animation: modal-appear 0.3s ease;
@@ -1631,25 +1817,25 @@ body.txt-virtual-controls-resizing * {
 	justify-content: space-between;
 	align-items: center;
 	padding: 15px 20px;
-	border-bottom: 1px solid #e0e0e0;
+	border-bottom: 1px solid var(--editor-surface-border);
 }
 
 .modal-header h2 {
 	margin: 0;
 	font-size: 1.5rem;
-	color: #333;
+	color: var(--editor-surface-fg);
 }
 
 .modal-close {
 	font-size: 1.8rem;
 	font-weight: bold;
-	color: #888;
+	color: var(--editor-description-fg);
 	cursor: pointer;
 	transition: color 0.2s;
 }
 
 .modal-close:hover {
-	color: #333;
+	color: var(--editor-surface-fg);
 }
 
 .modal-body {

--- a/media/html/blocklyEdit.html
+++ b/media/html/blocklyEdit.html
@@ -473,33 +473,29 @@
     </div>
     <!-- TXT 連線設定對話框 -->
     <div id="txtConnectionModal" class="modal">
-        <div class="modal-content" style="max-width: 520px;">
+        <div class="modal-content txt-connection-modal-content">
             <div class="modal-header">
                 <h2 id="txtConnectionPanelTitle">TXT Controller 連線設定</h2>
                 <span class="modal-close" id="txtModalClose">&times;</span>
             </div>
             <div class="modal-body">
-                <div
-                    style="display: grid; grid-template-columns: auto 1fr; gap: 8px 12px; align-items: center; margin-bottom: 12px;">
+                <div class="txt-connection-form-grid">
                     <label for="txtHostInput" id="txtHostLabel">Host IP</label>
-                    <input type="text" id="txtHostInput" placeholder="192.168.7.2"
-                        style="background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border); padding: 4px 8px; border-radius: 2px;">
+                    <input type="text" id="txtHostInput" class="txt-connection-input" placeholder="192.168.7.2">
                     <label for="txtUsernameInput" id="txtUsernameLabel">Username</label>
-                    <input type="text" id="txtUsernameInput" placeholder="ftc"
-                        style="background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border); padding: 4px 8px; border-radius: 2px;">
+                    <input type="text" id="txtUsernameInput" class="txt-connection-input" placeholder="ftc">
                     <label for="txtPasswordInput" id="txtPasswordLabel">Password</label>
-                    <input type="password" id="txtPasswordInput" placeholder="••••••••"
-                        style="background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border); padding: 4px 8px; border-radius: 2px;">
+                    <input type="password" id="txtPasswordInput" class="txt-connection-input" placeholder="••••••••">
                     <label for="txtRemotePathInput" id="txtRemotePathLabel">Remote Path</label>
                     <input type="text" id="txtRemotePathInput" placeholder="/tmp/singular_blockly/main.py"
-                        style="background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border); padding: 4px 8px; border-radius: 2px;">
+                        class="txt-connection-input">
                 </div>
-                <div style="display: flex; gap: 8px; align-items: center;">
-                    <button id="txtSaveConfigBtn" class="primary-btn" style="padding: 4px 12px;">儲存設定</button>
-                    <button id="txtTestConnectionBtn" class="secondary-btn" style="padding: 4px 12px;">測試連線</button>
-                    <span id="txtConnectionStatus" style="font-size: 0.85em;"></span>
+                <div class="txt-connection-actions">
+                    <button id="txtSaveConfigBtn" class="primary-btn txt-connection-action-button">儲存設定</button>
+                    <button id="txtTestConnectionBtn" class="secondary-btn txt-connection-action-button">測試連線</button>
+                    <span id="txtConnectionStatus" class="txt-connection-status"></span>
                 </div>
-                <p id="txtSshHint" style="margin: 8px 0 0; font-size: 0.8rem; color: #888;"></p>
+                <p id="txtSshHint" class="txt-connection-hint"></p>
             </div>
         </div>
     </div>

--- a/media/js/blocklyEdit.js
+++ b/media/js/blocklyEdit.js
@@ -2374,13 +2374,13 @@ function updateTxtConnectionPanelTexts() {
 				'TXT_SSH_SETUP_DONE',
 				'✓ SSH setup complete. Future connections will not require confirmation on the TXT screen.'
 			);
-			sshHint.style.color = 'var(--vscode-testing-iconPassed, #73c991)';
+			sshHint.classList.add('txt-connection-hint-success');
 		} else {
 			sshHint.textContent = languageManager.getMessage(
 				'TXT_SSH_CONFIRM_HINT',
 				'Tip: If the TXT screen shows a confirmation prompt, press OK on the device to allow SSH access.'
 			);
-			sshHint.style.color = '';
+			sshHint.classList.remove('txt-connection-hint-success');
 		}
 	}
 }
@@ -4803,6 +4803,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 			case 'loadWorkspace':
 				await handleWorkspaceLoadMessage(message);
 				break;
+			case 'updateTheme':
 			case 'setTheme':
 				// 直接從 VSCode 設定主題
 				currentTheme = message.theme || 'light';
@@ -5812,7 +5813,7 @@ function initTxtConnectionPanel() {
 			const statusEl = document.getElementById('txtConnectionStatus');
 			if (statusEl) {
 				statusEl.textContent = window.languageManager?.getMessage('TXT_TESTING', '連線中...');
-				statusEl.className = '';
+				statusEl.className = 'txt-connection-status';
 			}
 			vscode.postMessage({
 				command: 'txtTestConnection',
@@ -6477,7 +6478,8 @@ function handleTxtConnectionTestResult(message) {
 	const statusEl = document.getElementById('txtConnectionStatus');
 	if (statusEl) {
 		statusEl.textContent = message.message;
-		statusEl.className = message.success ? 'txt-status-ok' : 'txt-status-error';
+		statusEl.className = 'txt-connection-status';
+		statusEl.classList.add(message.success ? 'txt-status-ok' : 'txt-status-error');
 	}
 	if (message.sshSetupDone) {
 		txtSshSetupDone = true;

--- a/media/js/blocklyPreview.js
+++ b/media/js/blocklyPreview.js
@@ -919,14 +919,6 @@ function showBoardWarning(message) {
 	// 建立警告元素
 	const warningEl = document.createElement('div');
 	warningEl.className = 'board-warning';
-	warningEl.style.cssText = `
-		background-color: #ffc107;
-		color: #212529;
-		padding: 8px 16px;
-		font-size: 13px;
-		text-align: center;
-		border-bottom: 1px solid #e0a800;
-	`;
 	warningEl.textContent = message;
 
 	// 插入到 preview-info 後面

--- a/media/js/txtVirtualControlsContrast.js
+++ b/media/js/txtVirtualControlsContrast.js
@@ -289,7 +289,13 @@
 		if (classList?.contains('vscode-high-contrast')) {
 			return 'high-contrast';
 		}
-		if (classList?.contains('theme-dark') || classList?.contains('vscode-dark')) {
+		if (classList?.contains('theme-dark')) {
+			return 'dark';
+		}
+		if (classList?.contains('theme-light')) {
+			return 'light';
+		}
+		if (classList?.contains('vscode-dark')) {
 			return 'dark';
 		}
 		return 'light';

--- a/specs/057-editor-theme-surface-consistency/checklists/requirements.md
+++ b/specs/057-editor-theme-surface-consistency/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: 編輯器主題 surface 一致性
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 本規格已將「全面統一提示方法」明確移出本輪範圍，只保留 touched surfaces 的最小提示守則，避免 scope creep。
+- P1 聚焦於最直接影響使用者感受的 editor-owned 主題外洩：TXT 連線設定視窗、Sample Browser 與 TXT virtual controls chrome。
+- 所有澄清問題已在規格建立前收斂完成，因此沒有保留任何 [NEEDS CLARIFICATION] 標記。

--- a/specs/057-editor-theme-surface-consistency/contracts/theme-surface-ownership-contract.md
+++ b/specs/057-editor-theme-surface-consistency/contracts/theme-surface-ownership-contract.md
@@ -1,0 +1,91 @@
+# Contract：Theme Surface Ownership
+
+## 目的
+
+本契約定義 Blockly editor-owned surfaces 的主題 ownership：凡屬於 Blockly editor 內的主要操作 surface，必須跟隨 `singular-blockly.theme` 所代表的 editor theme，而不是 VS Code host theme。
+
+## 適用範圍
+
+### P1 必修 surfaces
+
+| Surface | 主要檔案 | 必須符合的範圍 |
+|---|---|---|
+| TXT connection modal | `media/html/blocklyEdit.html`, `media/css/blocklyEdit.css` | modal body、標籤、input、password/path 欄位、SSH hint、主要/次要按鈕、status/hint text |
+| Sample Browser | `media/html/blocklyEdit.html`, `media/css/blocklyEdit.css`, `media/js/blocklyEdit.js` | modal shell、offline notice、loading spinner/status、category header、sample card、empty state、action button |
+| TXT virtual controls editor chrome | `media/css/blocklyEdit.css`, `media/js/blocklyEdit.js` | panel shell、header、tabs、toolbar、canvas background/chrome、inspector、splitter、badge、warning/invalid reference chrome |
+
+### Opportunistic surfaces
+
+| Surface | 規則 |
+|---|---|
+| Shadow suggestion hint / AI suggestion overlays | 若本輪實作有修改，必須使用 editor theme 並即時更新；若未修改，只做 smoke-check 紀錄，不作為 completion gate。 |
+
+### 排除範圍
+
+| Surface | 排除原因 |
+|---|---|
+| `media/css/platformioDiagnostic.css` | 這是 standalone diagnostic page，設計上可跟隨 VS Code host theme。 |
+| VS Code workbench native UI | 不屬於 Blockly editor WebView。 |
+| Blockly block fill/stroke 本身 | 由 Blockly theme object 管理，非本契約的自訂 surface base UI。 |
+
+## Ownership 規則
+
+### 必須使用 editor theme 的 CSS 軸
+
+- Core surface selectors 必須以 `body.theme-light` / `body.theme-dark` 或 editor-owned CSS custom properties 作為 base UI 的色彩來源。
+- Core surface 的 base UI 包含：
+  - `background`
+  - `color`
+  - `border-color`
+  - input/textarea/select 的 background/foreground/border
+  - card/list item background/foreground/border
+  - hint/notice/status 的 readable foreground/background
+  - scrollbar track/thumb（若在 editor-owned panel 中定義）
+
+### 禁止的 leakage pattern
+
+在 P1 surfaces 中，下列 pattern 不得作為 base UI 色彩來源：
+
+- HTML inline style 使用：
+  - `var(--vscode-input-background)`
+  - `var(--vscode-input-foreground)`
+  - `var(--vscode-input-border)`
+  - `var(--vscode-editor-background)`
+  - `var(--vscode-editor-foreground)`
+  - `var(--vscode-panel-border)`
+- P1 surface base selector 使用 `body.vscode-light` / `body.vscode-dark` 指派 editor-owned token。
+- 對 editor-owned surface 使用 host list/button/input tokens 作為主要背景、文字或邊界，除非列入 allowlist。
+- 使用低對比硬編碼色作為提示文字，例如在 light/dark 其中一邊不可讀的固定 `#888`。
+
+## 允許例外
+
+下列情況允許使用 host/system token，但必須在 code review 中能被辨識為例外而非 leakage：
+
+| 例外 | 允許內容 |
+|---|---|
+| High contrast / forced-colors | `body.vscode-high-contrast`、`body.vscode-high-contrast-light`、system colors、VS Code contrast/focus tokens |
+| Focus / contrast rings | `--vscode-focusBorder`、`--vscode-contrastActiveBorder`、`--vscode-contrastBorder` 等輔助邊界 token |
+| Font tokens | `--vscode-font-family`、`--vscode-editor-font-family`、monospace font tokens |
+| Standalone host-themed pages | `platformioDiagnostic.css` 等非 Blockly editor-owned page |
+| Existing control semantic colors | TXT virtual control 的使用者自訂按鈕顏色、狀態顏色可保留，但 chrome 必須 editor-themed |
+
+## Source-contract 檢查建議
+
+自動化測試可用文字/AST-lite 掃描以下 contract：
+
+1. `media/html/blocklyEdit.html`
+   - `#txtHostInput`、`#txtUsernameInput`、`#txtPasswordInput`、`#txtRemotePathInput` 不得含 inline `--vscode-input-*`。
+   - `#txtSshHint` 不得用固定 `#888` 作為唯一 color。
+2. `media/css/blocklyEdit.css`
+   - Sample Browser P1 selectors（例如 `.sample-card`、`.sample-offline-notice`、`.sample-category-header`）不得使用 host editor/panel base tokens 作為 primary background/border/foreground。
+   - TXT virtual controls editor chrome token 不得在 `body.vscode-light` / `body.vscode-dark` 下被指派為 base light/dark theme。
+   - 高對比、focus ring、font token 使用需符合 allowlist。
+3. `media/css/platformioDiagnostic.css`
+   - 不納入 editor-owned leakage failure。
+
+## 驗收條件
+
+- 在 VS Code 深色 + Blockly editor 淺色時，TXT connection modal、Sample Browser、TXT virtual controls chrome 都呈現淺色 editor surface。
+- 在 VS Code 淺色 + Blockly editor 深色時，同一批 surface 都呈現深色 editor surface。
+- 在 host/editor 主題相同時，不出現回歸或突兀混色。
+- 高對比 smoke check 中，主要邊界、焦點與文字仍可辨識。

--- a/specs/057-editor-theme-surface-consistency/contracts/theme-switch-update-contract.md
+++ b/specs/057-editor-theme-surface-consistency/contracts/theme-switch-update-contract.md
@@ -1,0 +1,116 @@
+# Contract：Theme Switch Immediate Update
+
+## 目的
+
+本契約定義 editor theme 切換時，已開啟的 Blockly editor-owned surfaces 必須即時更新且保持操作狀態，不得依賴 WebView reload。
+
+## Theme source of truth
+
+- 持久化設定：`singular-blockly.theme`
+- Extension Host service：`src/services/settingsManager.ts`
+- WebView initial injection：`src/webview/webviewManager.ts`
+  - `window.initialTheme`
+  - `<body class="theme-{theme}">`
+- WebView runtime update：`media/js/blocklyEdit.js`
+  - `currentTheme`
+  - `updateTheme(theme)`
+  - Blockly `workspace.setTheme(...)`
+
+## 觸發情境
+
+### 情境 A：WebView toolbar theme toggle
+
+**Given** Blockly editor 已開啟，且任一 P1 surface 可見。  
+**When** 使用者按下 editor 內主題切換按鈕。  
+**Then** WebView 必須：
+
+1. 更新 `currentTheme`。
+2. 呼叫 `updateTheme(nextTheme)`。
+3. 將 `body.theme-light` / `body.theme-dark` 切到新值。
+4. 套用 Blockly theme object。
+5. 保留已開啟 surface 的 open state 與輸入內容。
+6. 將 `{ command: 'updateTheme', theme: nextTheme }` 傳回 Extension Host 持久化。
+
+### 情境 B：Extension Host command `singular-blockly.toggleTheme`
+
+**Given** Blockly editor WebView 已存在。  
+**When** 使用者透過 VS Code command 切換 Singular Blockly theme。  
+**Then** Extension Host 必須：
+
+1. 更新 settings 中的 editor theme。
+2. 對現有 panel 發送 `updateTheme` 或等效 message。
+3. WebView 收到後呼叫 `updateTheme(theme)`。
+4. 不重設 `webview.html`，不 reload WebView。
+
+### 情境 C：Workspace load message 帶入 theme
+
+**Given** WebView 正在載入 workspace state。  
+**When** message 包含有效 `theme`。  
+**Then** WebView 必須以該 theme 更新 editor-owned body class 與 Blockly theme。
+
+### 情境 D：已開啟 surface 的即時更新
+
+**Given** 下列任一 surface 已開啟：
+
+- TXT connection modal
+- Sample Browser
+- TXT virtual controls panel/chrome
+- 任何本輪有修改的 secondary overlay
+
+**When** editor theme 從 light 切到 dark 或從 dark 切到 light。  
+**Then** surface 必須在不關閉、不重新開啟、不 reload WebView 的情況下更新：
+
+- 背景
+- 前景文字
+- 邊界
+- input/field 顏色
+- card/list/notice 顏色
+- focus/hover/active 狀態（若目前可見或可操作）
+- TXT virtual controls chrome；使用者自訂控制色需保留
+
+### 可觀測更新門檻
+
+「即時更新」的通過標準為：使用者觸發 editor theme switch 後，WebView 不 reload、surface 不關閉再開啟；`updateTheme(theme)` 完成後下一次瀏覽器 repaint 必須呈現新 editor theme。已開啟 surface 的 input value、scroll state、modal open state、TXT virtual controls 配置與使用者自訂 control colors 必須保留。
+
+## 禁止行為
+
+- 不得為了套用 theme 而重新指定整個 `panel.webview.html`。
+- 不得要求使用者關閉再開啟 modal/browser/panel。
+- 不得只更新 Blockly workspace 本身而漏掉 editor-owned custom surface。
+- 不得讓 host `body.vscode-*` class 決定 P1 surface base light/dark。
+
+## JS/CSS 實作期待
+
+### CSS-first surface
+
+若 surface 的顏色可由 CSS custom properties 與 body class 完成，應優先使用 CSS-first：
+
+- `body.theme-light` / `body.theme-dark` 改變 token。
+- surface selectors 讀取 token。
+- 切換時瀏覽器自動 repaint。
+
+### JS-computed surface
+
+若 surface 仍有必要使用 JS 計算 inline style（例如 TXT virtual controls canvas/control preview），切換時必須由既有或新增 refresh function 更新：
+
+- `updateTheme(theme)` 呼叫 `refreshTxtVirtualControlsUI()` 或等效函式。
+- refresh 不得改變使用者配置資料。
+- refresh 不得覆蓋使用者自訂 control colors。
+
+## Source-contract 檢查建議
+
+1. `media/js/blocklyEdit.js`
+   - `updateTheme(theme)` 應保留 body class 更新與 Blockly `setTheme`。
+   - 若 TXT virtual controls 有 JS-computed chrome 色，`updateTheme(theme)` 必須觸發刷新。
+2. `src/webview/webviewManager.ts`
+   - 初始 HTML 仍注入 `window.initialTheme` 與 body `theme-{theme}`。
+3. `src/extension.ts` / `src/webview/messageHandler.ts`
+   - WebView toolbar 與 Extension Host command 的持久化/同步 flow 不得被破壞。
+
+## 驗收條件
+
+- 切換 editor theme 時，已開啟的 TXT connection modal 不消失，欄位內容不被清空，且在 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 換色。
+- 切換 editor theme 時，已開啟的 Sample Browser 保留目前顯示狀態，卡片與 notice 在下一次瀏覽器 repaint 換色。
+- 切換 editor theme 時，TXT virtual controls chrome 在下一次瀏覽器 repaint 換色，但 custom button/control colors 不被重設。
+- VS Code host theme 不變時，editor theme 切換仍能獨立生效。
+- VS Code host theme 與 editor theme 交錯時，P1 surfaces 跟隨 editor theme。

--- a/specs/057-editor-theme-surface-consistency/contracts/touched-feedback-rules-contract.md
+++ b/specs/057-editor-theme-surface-consistency/contracts/touched-feedback-rules-contract.md
@@ -1,0 +1,94 @@
+# Contract：Touched Feedback Rules
+
+## 目的
+
+本契約約束 057 中「被碰到的提示/說明/狀態元素」如何被主題化。它不是全域 feedback framework，也不重新定義所有提示方法；只確保本輪 touched elements 在 editor theme 下可讀、角色不變、且不因 theme 修正引入新的互動成本。
+
+## 適用元素
+
+下列元素若在本輪被修改，需符合本契約：
+
+| 元素類型 | 範例 | 本輪目標 |
+|---|---|---|
+| Inline hint | TXT SSH hint、TXT virtual controls 說明文字 | 改用 editor-owned description token，保持說明角色 |
+| Notice | Sample Browser offline notice、empty state | 改用 editor-owned notice token，保持原本顯示位置與語氣 |
+| Loading/status | Sample Browser loading spinner/status、connection status | 保持狀態含義，確保 light/dark 可讀 |
+| Warning/invalid state | TXT virtual controls invalid references 或警告 chrome | 保持 warning role，顏色跟 editor theme 協調 |
+| Secondary overlay hint | Shadow suggestion hint（若 touched） | 不列為 P1，但 touched 時需跟 editor theme 且即時更新 |
+
+## 非目標
+
+057 不做以下工作：
+
+- 不建立全域 feedback taxonomy。
+- 不把所有 hint/notice/warning/toast/block warning 合併成同一元件。
+- 不更改現有提示的主要互動模式。
+- 不新增大規模 i18n 文案重寫。
+- 不為所有 overlay 建立完整設計系統。
+
+## 規則
+
+### 規則 1：角色保留
+
+被修改的 feedback element 必須保留原本角色。
+
+- `hint` 還是 hint，不變成 modal 或 toast。
+- `offline notice` 還是 notice，不變成 blocking error。
+- `warning` 還是 warning，不降級成一般 description。
+
+若需要改變角色，必須另開規格，不在 057 完成。
+
+### 規則 2：可讀性優先
+
+Feedback element 必須使用 editor-owned token 或允許的 accessibility token，讓 light/dark editor theme 都可讀。
+
+- 不得只依賴固定 `#888` 這類在某些背景下可能低對比的顏色。
+- 不得用 host theme token 讓文字在交錯主題下變成 host-colored。
+- 高對比 smoke check 中不得消失或變成無法辨識。
+
+### 規則 3：重要資訊不得只靠 hover
+
+若提示承載操作必要資訊，不能改成 hover-only。
+
+- TXT connection SSH hint 應在需要時可直接看到。
+- Sample Browser offline/empty/loading 狀態應保留可見位置。
+- Tooltip 可作為補充，但不能是唯一資訊來源。
+
+### 規則 4：i18n 不回歸
+
+若本輪新增或修改 visible text：
+
+- 必須更新 `media/locales/*/messages.js` 的 15 語系。
+- 必須跑 `npm run validate:i18n`。
+- 長翻譯需在 Sample Browser/modal/panel 中保持不溢出主要操作區。
+
+若只改 CSS token、不改文字，可不新增 i18n key。
+
+### 規則 5：即時 theme update
+
+被修改的 feedback element 必須跟隨本輪 theme switch contract。
+
+- 已開啟 surface 中的 hint/notice/status 在 `updateTheme(theme)` 後立即換色。
+- 若 element 使用 CSS token，應由 body class repaint。
+- 若 element 使用 JS inline/computed style，必須納入 refresh flow。
+
+### 規則 6：不要擴張 selector 影響範圍
+
+為避免 scope creep，CSS selector 應鎖定本輪 surface 或共用 editor-owned token，不應用過寬 selector 意外改到 host-themed standalone pages。
+
+- 可使用 surface-specific class 或 modal/container selector。
+- 不應全域覆寫所有 `button`、`input`、`.notice`，除非位於 Blockly editor container 且已確認不影響排除頁面。
+
+## Source-contract 檢查建議
+
+- 若 `blocklyEdit.html` 的 hint style 被改動，確認沒有固定低對比 inline color。
+- 若 `blocklyEdit.css` 的 notice/status/warning selector 被改動，確認它們讀取 editor-owned token 或 allowlisted accessibility token。
+- 若新增 visible text，確認 i18n validation 納入 quickstart。
+- 若觸及 `shadowBlock.css`，確認 selector 不再只依賴 `body.vscode-light/dark` 來決定 editor-owned hint base theme，或在 plan/tasks 中記錄例外。
+
+## 驗收條件
+
+- 使用者在 P1 surfaces 中看到的提示/狀態文字在 editor light/dark 都清楚可讀。
+- Theme 修正後，提示元素仍出現在原本位置、扮演原本角色。
+- 沒有因本輪修改新增需要使用者學習的新提示互動模式。
+- 若可見文字有改，15 語系驗證通過。

--- a/specs/057-editor-theme-surface-consistency/data-model.md
+++ b/specs/057-editor-theme-surface-consistency/data-model.md
@@ -1,0 +1,191 @@
+# 資料模型：編輯器主題 surface 一致性
+
+## 實體：EditorThemePreference（編輯器主題偏好）
+
+**用途**：描述 Blockly editor 目前採用的獨立主題，不等同於 VS Code host theme。
+
+**欄位**：
+
+- `value`: `light` | `dark`
+- `storageKey`: 固定為 `singular-blockly.theme`
+- `initialInjection`: `window.initialTheme`
+- `bodyClass`: `theme-light` | `theme-dark`
+- `blocklyThemeObject`: `window.SingularBlocklyTheme` | `window.SingularBlocklyDarkTheme`
+
+**驗證規則**：
+
+- `value` 缺失或無效時預設為 `light`。
+- `bodyClass` 必須與 `value` 一致，且同一時間不得同時保留 `theme-light` 與 `theme-dark`。
+- 此 entity 不得由 `body.vscode-light` / `body.vscode-dark` 推導。
+
+## 實體：EditorOwnedSurface（編輯器擁有的主題表面）
+
+**用途**：定義本輪應跟隨 editor theme 的可見 UI surface。
+
+**欄位**：
+
+- `id`: 穩定識別，例如 `txt-connection-modal`、`sample-browser`、`txt-virtual-controls-chrome`
+- `priority`: `P1` | `P2` | `P3` | `opportunistic`
+- `selectors`: CSS selectors 或 DOM 節點 ID 列表
+- `sourceFiles`: 主要來源檔案，例如 `media/html/blocklyEdit.html`、`media/css/blocklyEdit.css`
+- `owner`: 固定為 `editor`
+- `surfaceParts`: `surface`、`field`、`button`、`card`、`notice`、`border`、`scrollbar`、`focus-ring`、`status` 的子集合
+- `mustUpdateImmediately`: `boolean`
+
+**驗證規則**：
+
+- P1 surface 的 `owner` 必須為 `editor`。
+- P1 surface 的 base background / foreground / border / field / card colors 不得直接取自 host `--vscode-*` token，除非該 token 被列在 `ThemeOwnershipException`。
+- `mustUpdateImmediately` 對本輪所有 touched surfaces 必須為 `true`。
+
+## 實體：ThemeTokenSet（主題 token 集合）
+
+**用途**：描述 editor-owned surface 在 light/dark/high-contrast 情境下可使用的語意色。
+
+**欄位**：
+
+- `mode`: `light` | `dark` | `high-contrast`
+- `surfaceBackground`: CSS color
+- `surfaceForeground`: CSS color
+- `surfaceBorder`: CSS color
+- `fieldBackground`: CSS color
+- `fieldForeground`: CSS color
+- `fieldBorder`: CSS color
+- `descriptionForeground`: CSS color
+- `cardBackground`: CSS color
+- `cardBorder`: CSS color
+- `warningBackground`: CSS color
+- `warningForeground`: CSS color
+- `warningBorder`: CSS color
+- `focusRing`: CSS color
+- `scrollbarTrack`: CSS color
+- `scrollbarThumb`: CSS color
+
+**驗證規則**：
+
+- `light` 與 `dark` 的 base token 應由 editor theme class 指派，不應由 `body.vscode-light/dark` 指派。
+- `high-contrast` 可使用 system colors、forced-colors 或 VS Code contrast tokens，但必須被明確視為 accessibility exception。
+- `focusRing` 可使用 contrast/focus 輔助 token；不得因此把整個 surface owner 改為 host。
+
+## 實體：ThemeLeakRecord（主題滲漏紀錄）
+
+**用途**：記錄待修正或已修正的 host theme leakage。
+
+**欄位**：
+
+- `surfaceId`: 對應 `EditorOwnedSurface.id`
+- `filePath`: 檔案路徑
+- `selectorOrElement`: CSS selector、DOM ID 或 HTML fragment
+- `property`: CSS property，例如 `background`、`color`、`border`
+- `leakSource`: `inline-vscode-token` | `body-vscode-selector` | `host-token-base-color` | `hardcoded-low-contrast` | `unknown`
+- `severity`: `blocking` | `must-fix` | `opportunistic` | `allowed-exception`
+- `resolution`: `replace-with-editor-token` | `move-to-allowlist` | `document-exception` | `not-touched`
+
+**驗證規則**：
+
+- P1 surface 的 `inline-vscode-token` 必須被標為 `blocking` 或 `must-fix`。
+- `allowed-exception` 必須連到 `ThemeOwnershipException`，不得只靠註解口頭說明。
+- `hardcoded-low-contrast` 若位於 touched feedback element，至少需改為 editor-owned token。
+
+## 實體：TouchedFeedbackElement（本輪觸及的提示元素）
+
+**用途**：描述本輪被外觀調整的既有提示、說明、狀態或提醒元素。
+
+**欄位**：
+
+- `id`: 穩定識別，例如 `txt-ssh-hint`、`sample-offline-notice`、`txt-virtual-controls-canvas-hint`
+- `parentSurfaceId`: 對應 `EditorOwnedSurface.id`
+- `role`: `hint` | `offline-notice` | `loading-status` | `empty-state` | `connection-status` | `warning` | `description`
+- `visibilityMode`: `always-visible-when-relevant` | `conditional-visible` | `aria-only` | `hover-only`
+- `messageKeys`: i18n key 列表；若沿用既有文字可為既有 key
+- `themeTokens`: 使用的 `ThemeTokenSet` token 名稱
+- `rolePreserved`: `boolean`
+
+**驗證規則**：
+
+- 重要指引不得只使用 `hover-only`。
+- 若新增或修改可見文字，`messageKeys` 必須在 15 語系中補齊。
+- `rolePreserved` 必須為 `true`，除非另有明確規格變更；057 不允許把既有 hint 改造成全新互動模式。
+
+## 實體：ThemeOwnershipException（主題 ownership 例外）
+
+**用途**：明確列出允許跟隨 host theme 或系統色的範圍。
+
+**欄位**：
+
+- `id`: 穩定識別
+- `scope`: `standalone-host-themed-page` | `high-contrast-accessibility` | `font-token` | `focus-contrast-token` | `semantic-status-token`
+- `filePaths`: 受影響檔案
+- `allowedTokens`: 可接受的 `--vscode-*` 或 system color token
+- `reason`: 例外原因
+- `reviewRequirement`: `documented-only` | `source-contract-allowlist` | `manual-smoke-check`
+
+**驗證規則**：
+
+- `standalone-host-themed-page` 不得套用到 TXT connection modal、Sample Browser、TXT virtual controls chrome。
+- `high-contrast-accessibility` 必須保留主要操作與邊界可辨識性。
+- `font-token` 僅允許字型或 monospace font family，不得夾帶 foreground/background。
+
+## 實體：ThemeSwitchScenario（主題切換情境）
+
+**用途**：描述使用者在 surface 已顯示時切換 editor theme 的即時更新要求。
+
+**欄位**：
+
+- `trigger`: `toolbar-toggle` | `extension-command` | `load-workspace-message` | `preview-sync`
+- `previousTheme`: `light` | `dark`
+- `nextTheme`: `light` | `dark`
+- `openSurfaces`: `EditorOwnedSurface.id[]`
+- `requiredActions`: `update-body-class`、`set-blockly-theme`、`refresh-inline-computed-ui`、`preserve-open-state` 的子集合
+- `mustReloadWebview`: 固定為 `false`
+
+**驗證規則**：
+
+- `previousTheme !== nextTheme` 時，`update-body-class` 與 `set-blockly-theme` 必須發生。
+- 若 `openSurfaces` 包含有 JS inline computed color 的 surface，必須包含 `refresh-inline-computed-ui` 或證明 CSS token 已足夠。
+- `mustReloadWebview` 不得為 `true`。
+
+## 實體：ManualThemeValidationScenario（手動主題驗證情境）
+
+**用途**：定義 quickstart manual matrix 中的可驗證情境。
+
+**欄位**：
+
+- `id`: 情境識別
+- `vscodeTheme`: `light` | `dark` | `high-contrast`
+- `editorTheme`: `light` | `dark`
+- `surfaces`: `EditorOwnedSurface.id[]`
+- `actions`: 驗證步驟
+- `expectedResult`: 可觀察結果
+- `result`: `pass` | `fail` | `not-run`
+- `notes`: 驗證紀錄
+
+**驗證規則**：
+
+- 至少需涵蓋四組 light/dark 組合：host light/editor light、host light/editor dark、host dark/editor light、host dark/editor dark。
+- 高對比為 smoke-check 等級，但不得出現阻礙核心操作的可讀性問題。
+- 每個 P1 surface 都必須出現在至少一個交錯主題情境中。
+
+## 關係
+
+- 一個 `EditorThemePreference` 會決定目前 active 的 `ThemeTokenSet.mode`。
+- 一個 `EditorOwnedSurface` 可包含多個 `TouchedFeedbackElement`。
+- 一筆 `ThemeLeakRecord` 必須對應一個 `EditorOwnedSurface` 或一個 `ThemeOwnershipException`。
+- 一個 `ThemeSwitchScenario` 會作用於多個 `EditorOwnedSurface`，並透過 `updateTheme(theme)` 或等效 message flow 實現。
+- 一個 `ManualThemeValidationScenario` 聚合多個 `EditorOwnedSurface` 與具體操作步驟。
+
+## 狀態轉移
+
+```mermaid
+stateDiagram-v2
+    [*] --> InitialInjected: WebViewManager 注入 window.initialTheme 與 body.theme-{theme}
+    InitialInjected --> EditorReady: Blockly.inject 完成
+    EditorReady --> SurfaceOpened: 使用者開啟 TXT modal / Sample Browser / virtual controls
+    SurfaceOpened --> ThemeToggleRequested: 使用者切換 editor theme
+    ThemeToggleRequested --> BodyClassUpdated: updateTheme 更新 body.theme-light/dark
+    BodyClassUpdated --> BlocklyThemeUpdated: workspace.setTheme 套用 Blockly theme
+    BlocklyThemeUpdated --> InlineUiRefreshed: 必要時 refreshTxtVirtualControlsUI 或等效重繪
+    InlineUiRefreshed --> SurfaceStillOpen: 不關閉、不 reload WebView
+    SurfaceStillOpen --> ValidationPassed: surface 與新 editor theme 一致且可讀
+    ValidationPassed --> SurfaceOpened
+```

--- a/specs/057-editor-theme-surface-consistency/manual-validation.md
+++ b/specs/057-editor-theme-surface-consistency/manual-validation.md
@@ -26,7 +26,7 @@
 | npm run lint | PASS | `eslint src`；exit 0 |
 | npm test | PASS | 765 passing、1 pending；exit 0 |
 | WebViewManager target test | PASS | `npx vscode-test --label unit --run out/test/webviewManager.test.js --grep "inject stored editor theme"`；exit 0（WebView Manager suite 28 passing） |
-| source-contract tests | PASS | `npm run compile-tests && npx mocha ...editorTheme*.test.js`；18 passing，exit 0；包含備份預覽 body theme ownership、preview chrome tokens、theme toggle focus ring、board warning class styling、TXT virtual controls scrollbar editor-owned token regression、高對比 forced-colors selectors |
+| source-contract tests | PASS | `npm run compile-tests && npx mocha ...editorTheme*.test.js`；19 passing，exit 0；包含備份預覽 body theme ownership、preview chrome tokens、theme toggle focus ring、board warning class styling、TXT virtual controls scrollbar editor-owned token regression、高對比 forced-colors selectors 與 TXT virtual controls running badge 可讀性 |
 | WebView preview target test | PASS | `npx vscode-test --label unit --run out/test/webviewPreview.test.js`；13 passing，exit 0；確認備份預覽載入與 TXT readonly preview flow 未受影響 |
 | npm run validate:i18n | PASS | 14/14 languages passed；0 errors，既有 length warnings 保留；本輪未變更 visible text |
 

--- a/specs/057-editor-theme-surface-consistency/manual-validation.md
+++ b/specs/057-editor-theme-surface-consistency/manual-validation.md
@@ -1,0 +1,38 @@
+# 057 手動驗證紀錄：編輯器主題 surface 一致性
+
+## 驗證矩陣
+
+| 情境 | VS Code host theme | Blockly editor theme | TXT modal | Sample Browser | TXT virtual controls | 結果 | 備註 / 截圖 |
+|---|---|---|---|---|---|---|---|
+| M1 | Dark | Light | 自動化通過 | 自動化通過 | 自動化通過 | 部分通過 | Source-contract tests 確認 editor-owned tokens、備份預覽 chrome / board warning / virtual controls scrollbar tokens 與 runtime `updateTheme(theme)`；本次 headless session 未開啟互動式 WebView，需人工複核畫面截圖 |
+| M2 | Light | Dark | 自動化通過 | 自動化通過 | 自動化通過 | 部分通過 | Source-contract tests 確認 editor-owned tokens 與 runtime `updateTheme(theme)`；本次 headless session 未開啟互動式 WebView，需人工複核畫面截圖 |
+| M3 | Dark | Dark | 自動化通過 | 自動化通過 | 自動化通過 | 部分通過 | Source-contract tests 確認相同 host/editor 主題下不依賴 host base tokens；需人工 smoke check |
+| M4 | Light | Light | 自動化通過 | 自動化通過 | 自動化通過 | 部分通過 | Source-contract tests 確認相同 host/editor 主題下不依賴 host base tokens；需人工 smoke check |
+| M5 | High Contrast | Light 或 Dark | 自動化通過 | 自動化通過 | 自動化通過 | 部分通過 | `editorThemeHighContrastContract.test` 通過，涵蓋 host-token allowlist、forced-colors P1 selectors 與備份預覽 chrome selectors；本次 headless session 未執行互動式截圖 smoke check，需人工以 VS Code 高對比主題複核主要文字、邊界、focus ring、主要按鈕、必要 status/hint |
+
+## 即時主題切換紀錄
+
+| Surface | 驗證項目 | 結果 | 備註 |
+|---|---|---|---|
+| TXT connection modal | 開啟時切換 editor theme，不 reload、不關閉、input value 保留，下一次 repaint 換色 | 自動化通過 / 手動未執行 | `editorThemeMainSurfaceSwitchContract.test` 與 `editorThemeSwitchContract.test` 確認 runtime path；需人工在 WebView 中複核 input value |
+| Sample Browser | 開啟時切換 editor theme，不 reload、不關閉、scroll state 盡量保留，下一次 repaint 換色 | 自動化通過 / 手動未執行 | `editorThemeMainSurfaceSwitchContract.test` 確認 Extension Host `updateTheme` 走 runtime path；需人工複核 scroll state |
+| TXT virtual controls | 開啟時切換 editor theme，不 reload、不覆蓋自訂 control colors，下一次 repaint 換色 | 自動化通過 / 手動未執行 | `editorThemeTxtVirtualControlsSwitchContract.test` 確認 refresh path 與 editor-theme fallback priority |
+
+## 自動化驗證紀錄
+
+| 命令 / 檢查 | 結果 | 備註 |
+|---|---|---|
+| npm run compile | PASS | `webpack 5.105.1 compiled successfully`；exit 0 |
+| npm run lint | PASS | `eslint src`；exit 0 |
+| npm test | PASS | 765 passing、1 pending；exit 0 |
+| WebViewManager target test | PASS | `npx vscode-test --label unit --run out/test/webviewManager.test.js --grep "inject stored editor theme"`；exit 0（WebView Manager suite 28 passing） |
+| source-contract tests | PASS | `npm run compile-tests && npx mocha ...editorTheme*.test.js`；18 passing，exit 0；包含備份預覽 body theme ownership、preview chrome tokens、theme toggle focus ring、board warning class styling、TXT virtual controls scrollbar editor-owned token regression、高對比 forced-colors selectors |
+| WebView preview target test | PASS | `npx vscode-test --label unit --run out/test/webviewPreview.test.js`；13 passing，exit 0；確認備份預覽載入與 TXT readonly preview flow 未受影響 |
+| npm run validate:i18n | PASS | 14/14 languages passed；0 errors，既有 length warnings 保留；本輪未變更 visible text |
+
+## 例外與排除紀錄
+
+| 項目 | 結果 | 理由 / 備註 |
+|---|---|---|
+| media/css/platformioDiagnostic.css | 已檢查 | `git status --short` 未列出此檔；仍為 standalone host-themed page，允許跟隨 VS Code host theme |
+| media/css/shadowBlock.css / secondary overlays | 未觸及 | `git status --short` 未列出此檔；本輪未修改 secondary overlay，依規格記錄為刻意不納入 |

--- a/specs/057-editor-theme-surface-consistency/plan.md
+++ b/specs/057-editor-theme-surface-consistency/plan.md
@@ -1,0 +1,139 @@
+# 實作計畫：編輯器主題 surface 一致性
+
+**分支**：`057-editor-theme-surface-consistency` | **日期**：2026-05-23 | **規格**：`specs/057-editor-theme-surface-consistency/spec.md`  
+**輸入**：來自 `specs/057-editor-theme-surface-consistency/spec.md` 的功能規格
+
+**註記**：本文件由 `/speckit.plan` 產生，範圍止於 Phase 2 規劃；實作任務清單會由後續 `/speckit.tasks` 產生。
+
+## 摘要
+
+本功能修正 Blockly 編輯器內 editor-owned surfaces 的主題 ownership，避免 VS Code host theme 經由 `body.vscode-*` 或 `--vscode-*` CSS variables 滲入主要編輯器視窗。核心範圍包含 TXT 控制器連線設定視窗、CyberBrick Sample Browser，以及 TXT virtual controls 的 editor-owned chrome；次要編輯輔助覆層（例如 shadow suggestion hint）只列為 smoke-check / opportunistic，不作為 057 完成門檻。全域 toast、warning、dialog、status taxonomy 不在本輪重構範圍內。
+
+技術方向是沿用現有 editor theme 流程：`SettingsManager` 儲存 `singular-blockly.theme`，`WebViewManager` 注入 `window.initialTheme` 與 `body.theme-{theme}`，`media/js/blocklyEdit.js` 的 `updateTheme(theme)` 切換 `body.theme-light` / `body.theme-dark` 並呼叫 Blockly `workspace.setTheme(...)`。本輪將 editor-owned surfaces 的背景、文字、邊界、表單欄位、卡片與提示樣式改由 editor-owned CSS tokens 控制；host-themed standalone pages 與高對比輔助例外需明確列入 allowlist。所有本輪 touched surfaces 在開啟狀態下切換 editor theme 時，都必須在不 reload WebView、不關閉再開啟 surface 的前提下，於 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 呈現新 editor theme。
+
+## 技術背景
+
+**語言/版本**：TypeScript 5.9.3（Extension Host 與測試）、JavaScript ES2020（WebView/Blockly UI）、HTML/CSS（VS Code WebView 與 Blockly editor chrome）  
+**主要相依項目**：VS Code API 1.105.0+、Blockly 12.3.1、`@blockly/theme-modern`、Mocha、Sinon、`@vscode/test-electron`、既有 `SettingsManager` / `WebViewManager` / `LocaleService`、`media/locales/*/messages.js`  
+**儲存**：不新增資料庫或 workspace schema；沿用 `.vscode/settings.json` 的 `singular-blockly.theme` 與既有 Blockly workspace JSON。若本輪新增或調整可見文字，需同步 15 語系 messages。  
+**測試**：Mocha + Sinon + `@vscode/test-electron` 既有測試；新增 source-contract tests 鎖定 HTML/CSS 主題 ownership；WebView 視覺互動依憲法 WebView 例外，以 quickstart manual matrix 驗證。  
+**目標平台**：VS Code 1.105+ 的 WebView（macOS / Windows / Linux）；主要回歸情境為 VS Code host light/dark 與 Blockly editor light/dark 交錯。  
+**專案型態**：VS Code 擴充功能（Extension Host + WebView browser context + Blockly editor）。  
+**效能目標**：主題切換透過 CSS variables / body class / 必要的現有 re-render 完成；不得透過重設 `webview.html` 造成 WebView 重新載入；切換已開啟 touched surfaces 時，`updateTheme(theme)` 完成後下一次瀏覽器 repaint 應呈現新 editor theme，且不新增背景輪詢。  
+**限制**：Extension Host TypeScript 不可 import WebView `media/` 程式碼；WebView 與 Extension Host 只透過 `postMessage`；editor-owned base surfaces 不得直接跟隨 `body.vscode-light/dark` 或 host `--vscode-*` 背景/文字/邊界 token；高對比與字型 token 可作為明確例外；不建立全域提示框架；不改刻意 host-themed standalone pages。  
+**範圍**：P1 必修為 TXT connection modal、Sample Browser、TXT virtual controls editor-owned chrome；P2 為本輪觸及提示的最小可讀性與角色保留；P3 為高對比 smoke check；shadow suggestion hint 等次要覆層只在本輪實際碰到時 opportunistic 修正。
+
+## 憲法檢查
+
+*關卡：Phase 0 research 前必須通過；Phase 1 design 後重新檢查。*
+
+| 原則 | 檢查結果 | 說明 |
+|---|---|---|
+| I. Simplicity and Maintainability | 通過 | 直接收斂為 theme ownership/token cleanup，不重寫整套 UI 或提示系統；優先移除明確 leakage 與 inline style。 |
+| II. Modularity and Extensibility | 通過 | 以 editor-owned CSS tokens、surface contract 與 allowlist 管理 ownership，避免每個 modal 各自硬編碼 host/theme 判斷。 |
+| III. Avoid Over-Development | 通過 | 已明確排除全域提示 taxonomy、所有次要覆層必修、host-themed standalone pages 改版與全面視覺重設計。 |
+| IV. Flexibility and Adaptability | 通過 | 保留現有 `light` / `dark` editor theme 設定與 Blockly theme object；高對比以 smoke-check 與明確例外支援。 |
+| V. Research-Driven Development | 通過 | 已查閱 VS Code WebView theming/theme color 官方文件與 Blockly theme/CSS 官方文件，並比對 repo 既有 theme 注入流程。 |
+| VI. Structured Logging | 通過 | 本階段不新增 Extension Host logging；後續若需 host 診斷必須使用 `log()` service，WebView console 僅限 browser context 既有偵錯用途。 |
+| VII. Comprehensive Test Coverage | 通過（含 WebView 例外） | CSS/HTML ownership 使用 source-contract tests；視覺一致性與交錯主題需以 quickstart manual matrix 記錄，符合 WebView manual testing exception。 |
+| VIII. Pure Functions and Modular Architecture | 通過 | 若新增 ownership scanner/contract helper，應以純文字/selector 檢查為主；DOM 即時更新集中在既有 `updateTheme(theme)` flow。 |
+| IX. Traditional Chinese Documentation Standard | 通過 | 本 plan、research、data model、contracts、quickstart 均以繁體中文撰寫。 |
+| X. Professional Release Management | 不適用 | 本階段不發布版本；若後續 release，另依 release workflow 處理。 |
+| XI. Agent Skills Architecture | 通過 | 依 SpecKit plan workflow 產出 artifacts；後續 commit/release 可使用既有 git/release skills。 |
+
+**設計後重新檢查**：通過。Phase 1 設計維持相同邊界：只規範 editor-owned surfaces、touched feedback 最小規則、theme switch 即時更新與 host-themed allowlist；未引入新框架、新 package 或跨 context import。
+
+## 專案結構
+
+### 文件（本功能）
+
+```text
+specs/057-editor-theme-surface-consistency/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   ├── theme-surface-ownership-contract.md
+│   ├── theme-switch-update-contract.md
+│   └── touched-feedback-rules-contract.md
+└── tasks.md              # 後續 /speckit.tasks 產生，本階段不建立
+```
+
+### 原始碼（儲存庫根目錄）
+
+```text
+media/
+├── html/
+│   └── blocklyEdit.html                  # TXT connection modal inline host-theme styles 需改為 class/token；核心 HTML surface
+├── css/
+│   ├── blocklyEdit.css                   # editor-owned tokens、modal/Sample Browser/TXT virtual controls chrome、high contrast smoke styles
+│   ├── shadowBlock.css                   # 次要覆層 opportunistic；若 touched，需改用 editor theme 或記錄例外
+│   └── platformioDiagnostic.css          # 刻意 host-themed standalone page；本輪 allowlist，不修改
+├── js/
+│   ├── blocklyEdit.js                    # `updateTheme(theme)` 即時更新鏈；必要時 refresh touched inline/computed UI
+│   └── txtVirtualControlsContrast.js     # TXT virtual controls fallback contrast 判斷；需以 editor theme class 優先
+└── locales/
+    └── */messages.js                     # 僅當本輪新增/修改可見文字時更新 15 語系
+
+src/
+├── services/
+│   └── settingsManager.ts                # 既有 `singular-blockly.theme` persistence；預期不需重構
+├── webview/
+│   └── webviewManager.ts                 # 既有 `window.initialTheme` / `body.theme-{theme}` 注入；測試可鎖定不回歸
+└── test/
+    ├── suite/
+    │   ├── editorThemeSurfaceContract.test.ts   # 建議新增：核心 surfaces 不得使用未允許 host vars/inline styles
+    │   └── txtVirtualControlsPersistence.test.ts # 既有 pattern 可參考或補充 TXT virtual controls source contract
+    ├── webviewManager.test.ts            # 既有 initial theme injection 測試，視需要補強
+    └── helpers/
+        └── mocks.ts
+```
+
+**結構決策**：採既有單一 VS Code extension 專案結構，不新增 package 或 WebView framework。主題一致性主要由 `media/css/blocklyEdit.css` 與 `media/html/blocklyEdit.html` 修正；`media/js/blocklyEdit.js` 承擔既有 theme switch / re-render 串接，`media/js/txtVirtualControlsContrast.js` 僅在 TXT virtual controls fallback contrast 判斷需要時調整為 editor theme 優先，不建立新狀態管理器。測試以 source-contract 鎖定 ownership 邊界，視覺驗證由 `quickstart.md` manual matrix 補足。
+
+## 複雜度追蹤
+
+> 本功能沒有憲法違規，因此不需要複雜度例外。
+
+| 違規項目 | 為何需要 | 為何不採用更簡單替代方案 |
+|---|---|---|
+| 不適用 | 不適用 | 不適用 |
+
+## Phase 0 研究輸出
+
+- `research.md` 記錄：editor theme ownership 應以 `body.theme-light` / `body.theme-dark` 為軸；核心 editor-owned base surfaces 不直接使用 host `--vscode-*`；HTML inline style 是高風險 leakage；`updateTheme(theme)` 應以 postMessage / body class 即時更新而非 reload WebView；高對比與 host-themed standalone pages 需作為明確例外。
+- 已查閱 VS Code WebView API、VS Code Theme Color、Blockly Themes 與 Blockly CSS 官方文件，確認 WebView host theme classes/CSS variables 的適用性、Blockly dynamic theme switching 與 CSS cascade/inline style 風險。
+- 已解決 Technical Context 中的未知項；沒有保留 `NEEDS CLARIFICATION`。
+
+## Phase 1 設計與契約輸出
+
+- `data-model.md` 定義 `EditorThemePreference`、`EditorOwnedSurface`、`ThemeTokenSet`、`ThemeLeakRecord`、`TouchedFeedbackElement`、`ThemeOwnershipException`、`ThemeSwitchScenario` 與 `ManualThemeValidationScenario`。
+- `contracts/theme-surface-ownership-contract.md` 定義核心 surface、allowlist、禁止/允許 host token 類型與 source-contract 驗收規則。
+- `contracts/theme-switch-update-contract.md` 定義 initial theme、toolbar toggle、Extension Host command、已開啟 touched surfaces 與 opportunistic overlay 的即時更新契約。
+- `contracts/touched-feedback-rules-contract.md` 定義本輪觸及提示的角色保留、可讀性、非 hover-only、i18n 與長字串處理契約。
+- `quickstart.md` 提供自動化命令與手動 light/dark/high-contrast 驗證矩陣。
+- Agent context 已更新為指向本 plan；本機只存在 PowerShell 版 update-agent-context 腳本且 `pwsh` 不可用，因此採等效 marker 更新。
+
+## Phase 2 任務實作大綱
+
+1. 建立 editor-owned theme tokens：在 `blocklyEdit.css` 補齊 modal、form、card、notice、scrollbar、focus、warning 等 `body.theme-light` / `body.theme-dark` token，避免核心 surface base colors 綁 host tokens。
+2. 修正 TXT connection modal：移除 `blocklyEdit.html` 中 `#txtHostInput`、`#txtUsernameInput`、`#txtPasswordInput`、`#txtRemotePathInput` 的 inline `--vscode-input-*`，改用 class 與 CSS token；`#txtSshHint` 改用 editor-owned description token。
+3. 修正 Sample Browser：讓 `#sampleModal`、`.sample-card`、`.sample-category-header`、`.sample-offline-notice`、loading/empty 狀態跟隨 editor theme，並處理 scrollbar/long text 可讀性。
+4. 修正 TXT virtual controls chrome：將 panel/splitter/canvas/inspector/mode badge/warning chrome 的 base colors 從 host token 改為 editor-owned token；保留使用者自訂 virtual button 顏色與必要 focus/high-contrast ring。
+5. 檢查 `updateTheme(theme)` 即時更新：確認已開啟 TXT modal、Sample Browser、TXT virtual controls 在切換 editor theme 後不需重開，且 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 呈現新 editor theme；若有 inline computed styles（例如 virtual control buttons）需在 `refreshTxtVirtualControlsUI()` 或等效流程中重繪。TXT virtual controls fallback contrast 判斷需在 `txtVirtualControlsContrast.js` 優先讀取 editor theme class，而不是 host `vscode-dark`。
+6. 處理 touched feedback 最小規則：本輪碰到的 hint/offline/status text 保留原角色，改用 editor-owned tokens；若改動可見文字，補齊 15 語系並通過 i18n validation。
+7. 補 source-contract tests：鎖定核心 surfaces 不再直接使用未允許的 host `--vscode-*` base tokens、TXT modal 不含 inline host input style、host-themed allowlist 不被誤改。
+8. 依 `quickstart.md` 執行手動矩陣，記錄 VS Code/editor 交錯主題、高對比 smoke check 與 immediate theme switch 結果。
+
+## 風險與驗證說明
+
+- **主要風險：host token false positive / false negative**。並非所有 `--vscode-*` 都是錯；字型、高對比、contrast/focus 輔助與 host-themed standalone pages 可例外。contract tests 需用 allowlist，避免把 `platformioDiagnostic.css` 或高對比支援誤判。
+- **主要風險：inline style specificity**。TXT modal 目前 input inline style 的 specificity 高於 CSS selector，若只在 CSS 加規則而不移除/覆蓋 inline style，仍可能保留 host theme leakage。
+- **主要風險：theme switch 即時性**。純 CSS tokens 會自動更新，但 TXT virtual controls button 使用 JS inline `backgroundColor` / `color` 呈現使用者自訂顏色；切換 theme 時需確認 fallback/default style 會重算並重繪，且 `txtVirtualControlsContrast.js` 不再以 host `vscode-dark` 作為 editor-owned fallback 的優先判斷。
+- **主要風險：scope creep**。提示統一只限本輪 touched feedback 的可讀性與角色保留，不建立全域 toast/dialog/status framework。
+- **主要風險：高對比回歸**。修掉 host leakage 後仍需保留高對比可辨識性；通過標準為主要文字可讀、input/card/panel 邊界可辨識、focus ring 可見、主要操作按鈕可辨識、必要 status/hint 沒有消失；可使用 system colors / `forced-colors` / contrast border 作為明確例外。
+- **驗證標準**：`npm run compile`、`npm run lint`、必要的 focused Mocha source-contract tests、`npm run validate:i18n`（若改可見文字）、`quickstart.md` 的 manual matrix。

--- a/specs/057-editor-theme-surface-consistency/quickstart.md
+++ b/specs/057-editor-theme-surface-consistency/quickstart.md
@@ -1,0 +1,126 @@
+# Quickstart：驗證編輯器主題 surface 一致性
+
+## 前置條件
+
+- 使用 VS Code / VS Code Insiders 開啟 `/Users/user/Documents/singular-blockly`。
+- 安裝專案依賴。
+- 以 Extension Development Host 啟動 Singular Blockly extension。
+- 能開啟 Blockly editor WebView。
+
+## 自動化驗證
+
+在實作完成後執行下列檢查：
+
+```bash
+npm run compile
+npm run lint
+npm test
+```
+
+若本輪新增或修改任何 visible text，另外執行：
+
+```bash
+npm run validate:i18n
+```
+
+若新增 source-contract test，建議至少確認它涵蓋：
+
+- TXT connection modal input 不再含 inline `--vscode-input-*` base style。
+- Sample Browser P1 selectors 不再用 host editor/panel base token 作為主要 surface color。
+- TXT virtual controls editor chrome 不再由 `body.vscode-light/dark` 決定 base light/dark token。
+- 高對比、focus ring、font token 等 allowlist 不被誤判。
+
+## 手動驗證矩陣
+
+> 記錄時請保留截圖或簡短 pass/fail note。高對比是 smoke check；light/dark 交錯情境是 P1 completion gate。即時更新的通過標準是：不 reload WebView、不關閉再開啟 surface，且 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 即顯示新 editor theme。
+
+| 情境 | VS Code host theme | Blockly editor theme | 必驗 surfaces | 預期結果 |
+|---|---|---|---|---|
+| M1 | Dark | Light | TXT modal、Sample Browser、TXT virtual controls | 三者呈現淺色 editor surface，不被 host 深色污染 |
+| M2 | Light | Dark | TXT modal、Sample Browser、TXT virtual controls | 三者呈現深色 editor surface，不被 host 淺色污染 |
+| M3 | Dark | Dark | TXT modal、Sample Browser、TXT virtual controls | 同色情境正常，無回歸或低對比 |
+| M4 | Light | Light | TXT modal、Sample Browser、TXT virtual controls | 同色情境正常，無回歸或低對比 |
+| M5 | High Contrast | Light 或 Dark | P1 surfaces smoke check | 主要文字可讀、input/card/panel 邊界可辨識、focus ring 可見、主要操作按鈕可辨識、必要 status/hint 沒有消失 |
+
+## 手動流程 A：TXT connection modal
+
+1. 開啟 Blockly editor。
+2. 將 VS Code host theme 設為 Dark。
+3. 將 Blockly editor theme 設為 Light。
+4. 開啟 TXT controller connection modal。
+5. 檢查：
+   - Modal shell 背景與文字符合 editor light theme。
+   - Host、Username、Password、Remote path input 為 editor light field style。
+   - Input 文字與 placeholder 可讀。
+   - `#txtSshHint` 說明文字可讀，不呈現 host 深色主題殘留。
+   - 按鈕與 status/hint 不混用 host 深色背景。
+6. 在 modal 保持開啟且 input 有內容時切換 Blockly editor theme 到 Dark。
+7. 確認：
+   - Modal 不關閉。
+   - Input 內容保留。
+   - `updateTheme(theme)` 完成後下一次瀏覽器 repaint 時，Modal、input、hint、button 顏色切到 editor dark theme。
+8. 反向切回 Light，再確認一次。
+
+## 手動流程 B：Sample Browser
+
+1. 開啟 Blockly editor。
+2. 開啟 Sample Browser modal。
+3. 在 M1 / M2 情境下分別檢查：
+   - Modal shell、header、body 背景符合 editor theme。
+   - Offline notice、loading spinner/status、empty notice 可讀。
+   - Category header、sample card、card hover/focus 狀態不使用 host theme base color。
+   - Card 內標題、描述、按鈕在 light/dark editor theme 都可讀。
+4. 在 Sample Browser 保持開啟時切換 Blockly editor theme。
+5. 確認 modal 不關閉、scroll position 盡量保留、可見 card/notice 在 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 換色。
+
+## 手動流程 C：TXT virtual controls editor chrome
+
+1. 開啟含 TXT virtual controls 的 workspace，或使用可觸發 virtual controls panel 的測試專案。
+2. 在 M1 / M2 情境下檢查：
+   - Panel shell、header、tabs、toolbar、splitter、canvas chrome、inspector 依 editor theme 顯示。
+   - Canvas 或 panel 中的 hint/warning/status 可讀。
+   - Invalid reference / badge / warning chrome 不被 host theme base color 污染。
+   - 使用者自訂 control/button 顏色保留，不被 editor theme token 覆蓋。
+3. 保持 virtual controls 開啟並切換 editor theme。
+4. 確認 chrome 在 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 換色，控制項配置與自訂顏色不重設。
+
+## 手動流程 D：secondary overlays smoke check
+
+1. 若本輪未修改 shadow suggestion hint，只需開啟 smoke check 並記錄是否有明顯低對比。
+2. 若本輪修改 `media/css/shadowBlock.css` 或相關 overlay：
+   - 在 M1 / M2 情境下觸發 shadow suggestion hint。
+   - 確認 hint 跟 editor theme，而不是 host theme。
+   - 在 hint 顯示時切換 editor theme，確認即時更新。
+
+## 手動流程 E：排除頁面不回歸
+
+1. 開啟 PlatformIO diagnostic UI 或相關 standalone host-themed page。
+2. 確認本輪 editor-owned token 變更沒有意外改壞 standalone page。
+3. 若該頁仍使用 `--vscode-*` host tokens，這是允許例外，不應被 057 source-contract 當成 failure。
+
+## 驗證紀錄格式
+
+可在 PR 或任務紀錄使用下列格式：
+
+```text
+057 manual matrix:
+- M1 VS Code Dark + Editor Light: PASS/FAIL, notes:
+- M2 VS Code Light + Editor Dark: PASS/FAIL, notes:
+- M3 VS Code Dark + Editor Dark: PASS/FAIL, notes:
+- M4 VS Code Light + Editor Light: PASS/FAIL, notes:
+- M5 High Contrast smoke: PASS/FAIL/NOT RUN, notes:
+
+Surfaces:
+- TXT connection modal: PASS/FAIL, notes:
+- Sample Browser: PASS/FAIL, notes:
+- TXT virtual controls chrome: PASS/FAIL, notes:
+- Secondary overlays if touched: PASS/FAIL/NOT TOUCHED, notes:
+```
+
+## 完成定義
+
+- 自動化驗證通過，或已記錄不可執行原因。
+- P1 manual matrix 通過。
+- 高對比 smoke check 通過：主要文字可讀、input/card/panel 邊界可辨識、focus ring 可見、主要操作按鈕可辨識、必要 status/hint 沒有消失，且沒有阻礙核心操作的可讀性問題。
+- 若有 touched feedback text 變更，15 語系驗證通過。
+- Implementation 沒有引入 WebView reload 來套用 editor theme。

--- a/specs/057-editor-theme-surface-consistency/research.md
+++ b/specs/057-editor-theme-surface-consistency/research.md
@@ -1,0 +1,117 @@
+# 研究紀錄：編輯器主題 surface 一致性
+
+## 決策 1：editor-owned surfaces 的主題 ownership 以 `body.theme-light` / `body.theme-dark` 為準
+
+**決策**：本輪納入的 Blockly editor-owned surfaces 一律以 editor theme class（`body.theme-light` / `body.theme-dark`）決定背景、文字、邊界、表單、卡片與提示底色，不以 VS Code host theme class（`body.vscode-light` / `body.vscode-dark`）作為 base surface 的主要來源。
+
+**理由**：目前 TXT connection modal 在 VS Code 深色、Blockly editor 淺色時出現深色 input，根因是 editor-owned modal 的 input inline style 使用 `--vscode-input-*` host tokens。VS Code 官方文件說明 WebView 可以使用 `body.vscode-light` / `body.vscode-dark` 與 `--vscode-*` 變數，這適合刻意跟隨 workbench 的 WebView；但本專案已有獨立 Blockly editor theme 設定，使用者期待 editor 內主要操作 surface 跟隨 editor theme 而非 host theme。
+
+**曾考慮的替代方案**：
+
+- 繼續使用 `--vscode-*` 並補 fallback：會在 host/editor 交錯主題時繼續混色，無法解決根因。
+- 讓 Blockly editor theme 跟著 VS Code theme：違反使用者可獨立切換 editor 主題的既有設計。
+- 每個 modal 用 JS 直接塞顏色：會增加狀態同步成本，且比 CSS token 更難維護。
+
+## 決策 2：用 editor-owned CSS tokens 收斂樣式，而不是分散硬編碼顏色
+
+**決策**：在 `media/css/blocklyEdit.css` 以 editor-owned CSS custom properties 建立 surface / field / border / description / warning / focus 等 token，並由 `body.theme-light` / `body.theme-dark` 賦值。核心 surface 的 selector 使用這些 token；必要的高對比或系統字型例外另列 allowlist。
+
+**理由**：現有 CSS 已有 `body.theme-light` / `body.theme-dark` pattern，且 `experimentalBlocks.css` 也展示了 editor-owned theme class 的可行做法。集中 token 可以讓 TXT modal、Sample Browser 與 TXT virtual controls chrome 共用語意色，減少每個區塊各自硬編碼 light/dark 顏色造成的漂移。
+
+**曾考慮的替代方案**：
+
+- 直接在每個 selector 寫固定 light/dark 顏色：短期可修，但長期難以盤點 ownership。
+- 把所有 WebView UI 全部改成一套新設計系統：超出 057 範圍，會變成全域 UI 重構。
+- 只修 TXT connection modal：無法回應已確認的 Sample Browser 與 TXT virtual controls chrome leakage 風險。
+
+## 決策 3：移除核心 modal 的高風險 inline host style，而不是只加更高 specificity 的 CSS
+
+**決策**：TXT connection modal 中 `#txtHostInput`、`#txtUsernameInput`、`#txtPasswordInput`、`#txtRemotePathInput` 的 inline `background/color/border: var(--vscode-input-*)` 應移除，改成 class 或共用 selector 套用 editor-owned field tokens。`#txtSshHint` 的硬編碼 `#888` 也應改為 editor-owned description token。
+
+**理由**：Blockly CSS 官方文件提醒 inline style 的 specificity 高於一般 selector；若只在 stylesheet 補規則，容易需要 `!important` 或仍被 inline style 壓過。把 style ownership 回收至 CSS file，可同時降低 specificity 風險與後續維護成本。
+
+**曾考慮的替代方案**：
+
+- 使用 `!important` 覆蓋 inline style：可行但不乾淨，且會讓未來表單狀態樣式更難調整。
+- 在 `updateTheme(theme)` 逐一改 input style：增加 JS DOM 操作與漏改風險。
+- 保留 inline style 只改 fallback 色：仍會讀 host token，不符合 editor-owned ownership。
+
+## 決策 4：theme switch 使用既有 `updateTheme(theme)` 與 postMessage flow，不 reload WebView
+
+**決策**：本輪 theme switch 即時更新必須沿用既有 flow：WebView toolbar 或 Extension Host command 更新 theme，透過 `updateTheme(theme)` 切換 body class、Blockly theme object，並刷新必要的 inline/computed UI。不得透過重新指定 `webview.html` 達成更新。
+
+**理由**：VS Code WebView 文件說明 Extension Host 可用 `webview.postMessage()` 傳訊息給 WebView；同時重新設定 `webview.html` 會重設 WebView script state。此專案目前已使用 `retainContextWhenHidden` 與 `updateTheme(theme)`，重載 HTML 會破壞 workspace 狀態、開啟中的 modal、TXT virtual controls 狀態與使用者操作脈絡。
+
+**曾考慮的替代方案**：
+
+- 切主題時重建整個 WebView：狀態成本過高，且與 FR-016「開啟中的 surface 立即更新」精神不符。
+- 每個 modal 關閉再重開：使用者體驗差，且規格明確不接受。
+- 新增獨立 theme observer framework：本輪不需要，現有 `updateTheme(theme)` 足以承載。
+
+## 決策 5：核心範圍固定為三組 surface，secondary overlays 只 opportunistic
+
+**決策**：057 的完成門檻只要求：TXT connection modal、Sample Browser、TXT virtual controls editor-owned chrome。Shadow suggestion hint 等次要編輯輔助覆層列為 smoke-check / opportunistic；若本輪實作碰到它，必須符合 editor theme 與即時更新規則，否則不把它列為 blocking completion gate。
+
+**理由**：使用者已明確擔心「統一提示」會讓範圍過大。Spec clarify 也明確排除全域提示 taxonomy，並把 secondary overlays 定義為 opportunistic。此決策能避免 057 從 theme leakage 修復膨脹成所有提示/覆層治理。
+
+**曾考慮的替代方案**：
+
+- 把所有 WebView overlay 都列為必修：範圍過大且風險高。
+- 完全忽略 shadow hint：可能在 smoke check 中留下明顯不協調，但不應阻塞 P1 修復。
+- 新增完整 feedback framework：與本輪 scope control 衝突。
+
+## 決策 6：明確定義 host-themed allowlist，避免把例外和 leakage 混在一起
+
+**決策**：本輪 contract 需明確列出允許 host theme 的情況：刻意 host-themed standalone pages（例如 `media/css/platformioDiagnostic.css`）、高對比/forced-colors 支援、VS Code contrast/focus 輔助 token、字型 token。核心 editor-owned base surface 的背景、文字、邊界、表單與卡片 token 不應直接取自 host theme。
+
+**理由**：VS Code Theme Color 官方文件列出大量 host UI tokens，這些 token 對 workbench-like UI 有價值；但 057 要解決的是 editor-owned surface 被 host theme 覆蓋。若沒有 allowlist，後續 source-contract tests 容易誤判高對比支援或故意 host-themed page；若 allowlist 太寬，又會讓真正 leakage 溜過。
+
+**曾考慮的替代方案**：
+
+- 完全禁止所有 `--vscode-*`：會誤傷字型、高對比與刻意 host-themed page。
+- 完全依人工 review 判斷：容易回歸，缺少可測契約。
+- 只靠 selector 命名猜測 owner：不夠可靠，需搭配 surface allowlist。
+
+## 決策 7：測試採 source-contract + manual matrix，避免為 WebView 視覺互動引入大型測試框架
+
+**決策**：自動化測試以 source-contract 為主，檢查核心 HTML/CSS 不再含未允許 host base tokens 或 inline host input style，並鎖定 WebView initial theme injection 不回歸。實際視覺一致性、交錯主題與高對比情境，依 `quickstart.md` manual matrix 驗證並記錄。
+
+**理由**：專案憲法允許 WebView 互動視覺功能採手動測試，前提是規格與 quickstart 明確列出情境並記錄結果。為本輪 light/dark surface consistency 導入 Playwright/WebdriverIO 會超過 ROI；但完全無自動化又容易讓 `--vscode-*` leakage 回歸，因此 source-contract 是較輕量且可維護的平衡點。
+
+**曾考慮的替代方案**：
+
+- 全靠人工測試：無法防止 CSS/HTML ownership 回歸。
+- 建立完整 WebView E2E 視覺測試：基礎建設成本過高，不符合 057 範圍。
+- 只跑 compile/lint：無法捕捉 CSS/HTML theme leakage。
+
+## 決策 8：本輪 touched feedback 只保留角色與可讀性，不重新設計互動模式
+
+**決策**：本輪如果碰到 `#txtSshHint`、Sample Browser offline/loading/empty notice、TXT virtual controls hints/warnings 等 feedback elements，只調整 theme token、可讀性、非 hover-only 與 i18n 完整性；不把 toast、modal、inline hint、block warning 等角色重新分類或重命名。
+
+**理由**：使用者最終選擇縮小提示統一範圍。057 的價值在於「同一 editor 主題下看起來一致且可讀」，不是讓使用者重新學習新的提示方法。
+
+**曾考慮的替代方案**：
+
+- 一次建立全域 feedback taxonomy：過度開發且會牽動大量既有流程。
+- 不管 feedback 元素：若 touched surface 內提示文字仍不可讀，會違反 FR-007/FR-009。
+- 把所有提示改成 toast：會改變使用情境與資訊可見性，不符合角色保留。
+
+## 參考依據
+
+- VS Code WebView API 官方文件：WebView 可接收 `postMessage`、會有 `body.vscode-light` / `body.vscode-dark` / `body.vscode-high-contrast` host theme classes，且高對比需要測試。
+- VS Code Theme Color 官方文件：host theme colors 可作為 WebView CSS variables，但 token 語意屬於 workbench/host UI。
+- Blockly Themes 官方文件：Blockly workspace 支援 theme component styles 與 dynamic theme switching。
+- Blockly CSS 官方文件：可用 CSS 覆寫 Blockly/自訂元件樣式；inline style specificity 高於一般 selector。
+- Repo 既有實作：`src/webview/webviewManager.ts`、`src/services/settingsManager.ts`、`media/js/blocklyEdit.js`、`media/css/blocklyEdit.css`、`media/html/blocklyEdit.html`、`media/css/experimentalBlocks.css`。
+- Repo memory：`/memories/repo/editor-theme-isolation.md`、`/memories/repo/txt-connection-ux-decisions.md`、`/memories/repo/txt-virtual-controls-runtime.md`。
+
+## 結論
+
+Phase 0 所需未知項已收斂：
+
+- 057 不需要新增 theme framework 或重載 WebView。
+- 核心修復路徑是 editor-owned CSS tokens + 移除 inline host style + source-contract tests。
+- Host theme 不是全面禁止，而是只允許在明確例外、高對比與輔助 token 中使用。
+- Touched feedback 只做可讀性與角色保留，不做全域提示治理。
+
+本功能可進入 Phase 1 設計與契約定義，且沒有未解的 `NEEDS CLARIFICATION`。

--- a/specs/057-editor-theme-surface-consistency/spec.md
+++ b/specs/057-editor-theme-surface-consistency/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: 編輯器主題 surface 一致性
+
+**Feature Branch**: `057-editor-theme-surface-consistency`  
+**Created**: 2026-05-23  
+**Status**: Draft  
+**Input**: User description: 「在 VS Code 深色模式下，即使 Blockly 編輯器切到淺色，編輯器內的主題也應保持一致，不受 VS Code host theme 干涉；這次先聚焦 editor-owned surfaces 的主題一致性，不把全面統一提示方法納入同一輪。」
+
+## Clarifications
+
+### Session 2026-05-23
+
+- Q: 這一輪是否要全面統一所有提示方法？ → A: 不需要。本輪只修正 editor-owned 主題 surface 一致性，僅對本輪觸及到的提示補最小的一致性與可讀性守則，不建立全域提示框架。
+- Q: 哪些區塊屬於本輪核心範圍？ → A: 至少包含 TXT 控制器連線設定視窗、Sample Browser，以及 TXT virtual controls 的 editor-owned chrome；次要編輯輔助覆層屬 smoke-check / opportunistic 範圍，若本輪剛好碰到可一起修，但不作為 057 完成門檻。
+- Q: 是否要一併調整刻意跟隨 VS Code 主題的獨立頁面？ → A: 不需要。刻意 host-themed 的獨立頁面維持現狀，不納入本輪修正。
+- Q: 次要編輯輔助覆層（例如 shadow suggestion hint）在 057 應算哪種 scope？ → A: 列為 smoke-check / opportunistic 範圍；若本輪剛好碰到可一起修，但不作為 057 完成門檻。
+- Q: 當使用者在視窗已開啟時切換 Blockly editor 主題，057 應要求哪種更新行為？ → A: 所有本輪 touched surfaces 都必須立即更新；若次要覆層在本輪被觸及，也必須在主題切換時立即更新，而不是等到下次開啟。
+- Q: 「立即更新」如何判定？ → A: 使用者觸發 editor theme switch 後，不得 reload WebView、不得關閉再開啟 surface；`updateTheme(theme)` 完成後，下一次瀏覽器 repaint 應呈現新 editor theme，且已輸入內容、scroll state 與使用者自訂控制顏色需保留。
+- Q: 高對比 smoke check 的最低通過標準是什麼？ → A: 主要文字可讀、input/card/panel 邊界可辨識、focus ring 可見、主要操作按鈕可辨識、必要 status/hint 沒有消失，且使用者可完成核心操作。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 主要編輯器視窗在交錯主題下仍保持一致 (Priority: P1)
+
+教師或學生在 Blockly 編輯器中選擇了淺色或深色主題後，希望即使外層 VS Code 使用相反主題，像 TXT 控制器連線設定視窗與 Sample Browser 這些主要操作視窗仍看起來屬於同一個編輯器，而不是混入另一套配色與表單樣式。
+
+**Why this priority**: 這直接對應目前最明顯的體驗問題。若主要操作視窗仍混入 host theme，使用者會立刻感覺介面破碎，並誤以為設定沒有正確套用。
+
+**Independent Test**: 先把 VS Code 與 Blockly 編輯器切成相反主題，然後分別開啟 TXT 控制器連線設定視窗與 Sample Browser；若兩者都維持 editor theme 的一致外觀，此故事即可獨立驗證。
+
+**Acceptance Scenarios**:
+
+1. **Given** VS Code 為深色而 Blockly 編輯器為淺色，**When** 使用者開啟 TXT 控制器連線設定視窗，**Then** 視窗中的輸入欄、標籤、按鈕與說明文字都應與編輯器淺色主題一致，而不是混入深色 host 風格。
+2. **Given** VS Code 為淺色而 Blockly 編輯器為深色，**When** 使用者開啟 Sample Browser，**Then** 其視窗表面、卡片、按鈕與狀態提示都應與編輯器深色主題一致且容易閱讀。
+3. **Given** 使用者在主要視窗開啟期間切換 Blockly 編輯器主題，**When** 新主題生效，**Then** 已開啟的主要視窗也應立即更新為一致的新主題，而不需要關閉再重開。
+
+---
+
+### User Story 2 - 編輯器控制面與外框維持單一主題 owner (Priority: P1)
+
+教師或學生在使用 TXT virtual controls 等編輯器控制面時，希望外框、面板、控制區與狀態性表面看起來都屬於同一套編輯器主題；即使使用者為控制元件挑選自己的顏色，周圍的編輯器外框也不應突然像另一個應用程式。
+
+**Why this priority**: 這影響的是整體信任感與可讀性。即使功能可用，若同一畫面中有一部分像 editor、一部分像 host，使用者仍會感覺主題切換失效或系統不穩定。
+
+**Independent Test**: 在交錯主題情境下開啟 TXT virtual controls，確認外框、面板與狀態性表面一致，同時控制元件自訂顏色仍保持清楚可辨識。
+
+**Acceptance Scenarios**:
+
+1. **Given** Blockly 編輯器與 VS Code 使用不同主題，**When** 使用者檢視 TXT virtual controls 的外框、面板與操作區，**Then** 這些 editor-owned 表面應保持單一主題 owner，而非同時混入兩套主題風格。
+2. **Given** 使用者已自訂某些控制元件顏色，**When** 檢視 virtual controls 的整體畫面，**Then** 編輯器外框與狀態性表面仍應清楚可辨，且不會因自訂顏色而失去可讀性。
+3. **Given** 本輪順手碰到某個次要編輯輔助覆層出現在畫面中，**When** 使用者查看其背景、文字與邊界，**Then** 其外觀應與目前編輯器主題相容，或被明確視為刻意例外。
+4. **Given** 本輪順手碰到的次要編輯輔助覆層正顯示在畫面上，**When** 使用者切換 Blockly 編輯器主題，**Then** 該覆層也應立即更新為新主題，而不是保留舊主題直到下次開啟。
+
+---
+
+### User Story 3 - 本輪觸及到的提示維持原意且更容易看懂 (Priority: P2)
+
+教師或學生在本輪會碰到的說明文字、離線提醒或輔助提示中，希望看到的仍是熟悉的提示方式，而不是突然變成另一種互動模式；同時這些提示必須在不同主題下仍清楚可讀，不需要把滑鼠移上去才知道重要資訊。
+
+**Why this priority**: 使用者這次要的是主題一致性，不是重新學一套提示系統。保留既有提示角色、只補最小可用性守則，能避免範圍膨脹又能提升體驗。
+
+**Independent Test**: 在本輪觸及的視窗中依序觸發既有說明文字或狀態提示，確認它們仍保留原本角色，且在兩種 editor 主題下都清楚可見。
+
+**Acceptance Scenarios**:
+
+1. **Given** 本輪觸及到的某個說明文字、離線提醒或輔助提示已存在，**When** 此功能調整其外觀，**Then** 它仍應保留原本的提示角色，而不是被改造成另一種全新互動方式。
+2. **Given** 某個本輪觸及的提示承擔重要指引功能，**When** 使用者以鍵盤、觸控板或一般點擊方式操作，**Then** 他不需要依賴滑鼠懸停才看得到關鍵資訊。
+3. **Given** 本輪改動到任何可見文字，**When** 使用者切換到任一支援語言，**Then** 這些文字都應保持完整、本地化且語意一致。
+
+---
+
+### User Story 4 - 在高對比與交錯主題情境下仍可完成核心操作 (Priority: P3)
+
+對需要較高可視對比的使用者來說，即使這次主要修的是 editor light/dark 一致性，至少也希望本輪觸及到的表面在高對比情境下不會出現明顯看不清、找不到按鈕或無法辨認提示的問題。
+
+**Why this priority**: 高對比不是這次的主軸，但若修完主題一致性卻讓某些表面更難看清，會抵銷本次改善的價值。
+
+**Independent Test**: 對本輪觸及的主要視窗做一次高對比 smoke check，確認仍能辨識主要操作、邊界與提示。
+
+**Acceptance Scenarios**:
+
+1. **Given** 使用者以高對比偏好的方式檢視本輪觸及的主要視窗，**When** 他查看主要按鈕、欄位與提示，**Then** 這些元素仍應可辨識，不會因主題調整而消失在背景中。
+2. **Given** 使用者在交錯主題情境下執行 TXT 連線設定、打開 Sample Browser 或檢視 virtual controls，**When** 他完成核心操作，**Then** 不需要透過切回相同主題或使用變通方式才能看懂介面。
+
+### Edge Cases
+
+- VS Code 與 Blockly 編輯器使用相反主題時，本輪納入的主要視窗不應出現一半像 editor、一半像 host 的混合外觀。
+- 使用者在主要視窗開啟期間切換 editor 主題時，畫面不應停留在舊主題的殘留狀態。
+- 若本輪觸及到的次要編輯輔助覆層正在顯示，切換 editor 主題後也不應殘留舊主題外觀直到下次開啟。
+- 使用者為 TXT virtual controls 選擇非常接近背景的自訂顏色時，外框、狀態性表面與主要操作仍應可辨識。
+- 離線提示、說明文字或輔助提示在較長翻譯字串下，仍應完整顯示並保持可讀。
+- 刻意 host-themed 的獨立頁面不應因本次修正而被意外改成 editor-themed。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 系統 MUST 讓 Blockly 編輯器維持獨立選定的淺色或深色主題，不受外層 VS Code 主題改變而被覆蓋。
+- **FR-002**: 所有列入本輪範圍的 editor-owned 表面 MUST 跟隨目前的 Blockly 編輯器主題，而不是跟隨外層 VS Code 主題。
+- **FR-003**: 本輪主要範圍 MUST 至少包含 TXT 控制器連線設定視窗與 Sample Browser 這兩個主要操作視窗。
+- **FR-004**: 在 TXT 控制器連線設定視窗中，輸入欄、標籤、按鈕與說明文字 MUST 與目前的編輯器主題保持一致且可讀。
+- **FR-005**: 在 Sample Browser 中，視窗表面、卡片、主要操作按鈕與狀態提示 MUST 與目前的編輯器主題保持一致且可讀。
+- **FR-006**: 在 TXT virtual controls 中，外框、面板、操作區與狀態性表面 MUST 與目前的編輯器主題保持一致，同時保留使用者自訂控制元件顏色的可辨識性。
+- **FR-007**: 本輪觸及到的說明文字、離線提醒與輔助提示 MUST 在淺色與深色 editor 主題下都保持可讀。
+- **FR-008**: 當本輪功能調整既有提示的外觀時，系統 MUST 保留該提示原本的角色與使用情境，除非為了維持可讀性或可用性而需要最小必要調整。
+- **FR-009**: 本輪觸及到的重要指引 MUST 在一般操作情境下可直接看見，MUST NOT 僅依賴滑鼠懸停才能取得。
+- **FR-010**: 本輪改動到的所有可見文字 MUST 在所有支援語言中維持完整且一致的本地化內容。
+- **FR-011**: 本輪納入的表面 MUST 在 Blockly 編輯器主題與 VS Code 主題相反時仍保持可用與可讀。
+- **FR-012**: 系統 MUST 明確區分 editor-owned 表面與刻意 host-themed 的例外頁面，且 MUST NOT 將刻意 host-themed 的獨立頁面納入本輪主題修正。
+- **FR-013**: TXT 連線設定、Sample Browser 與 TXT virtual controls 的既有核心操作 MUST 在本次主題一致性調整後保持可完成。
+- **FR-014**: 本輪觸及到的表面 MUST 讓使用者在不依賴單一顏色的情況下辨認主要操作、邊界與重要訊息。
+- **FR-015**: 若本輪順手碰到任何次要編輯輔助覆層，其外觀 MUST 與目前 editor 主題相容，或在發布前被明確記錄為刻意例外；但這些覆層本身 MUST NOT 成為 057 的完成門檻。
+- **FR-016**: 當使用者在本輪任一 touched surface 顯示期間切換 editor 主題，系統 MUST 在不 reload WebView、不關閉再開啟 surface 的前提下，於 `updateTheme(theme)` 完成後的下一次瀏覽器 repaint 讓該 surface 呈現新主題，並保留已輸入內容、scroll state 與使用者自訂控制顏色。
+
+### Key Entities *(include if feature involves data)*
+
+- **Editor-Owned Surface**: Blockly 編輯器內應跟隨 editor 主題的可見表面，例如主要操作視窗、面板、外框與說明區。
+- **Touched Feedback Element**: 本輪會被外觀調整的既有提示元素，例如說明文字、離線提醒或輔助提示；其角色應保持穩定，不重新定義成全新提示系統。
+- **Theme Ownership Exception**: 經過明確界定、刻意保留為 host-themed 的頁面或表面，不屬於本輪 editor theme 一致性修正範圍。
+- **Core Editor Workflow**: 使用者在本輪範圍內必須能持續完成的主要流程，包括設定 TXT 連線、瀏覽範例與檢視 TXT virtual controls。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 在至少四組 light/dark 驗證組合（包含相同與相反主題組合）的檢查矩陣中，100% 的 P1 範圍表面都不再出現混合主題造成的明顯錯配、不可讀文字或不協調表單外觀。
+- **SC-002**: 驗證人員能在每個必要主題組合中完成一次 TXT 連線設定檢視、一次 Sample Browser 開啟，以及一次 TXT virtual controls 檢視，而不需要切換回相同主題作為變通方式。
+- **SC-003**: 本輪改動到的所有可見文字在支援語言驗證樣本中皆保持完整本地化，且不出現硬編碼或遺漏翻譯。
+- **SC-004**: 本輪觸及到的重要說明文字與提示在兩種 editor 主題下都可直接看見，不需要依賴滑鼠懸停才理解核心操作。
+- **SC-005**: 在本輪觸及表面的高對比 smoke check 中，主要文字可讀、input/card/panel 邊界可辨識、focus ring 可見、主要操作按鈕可辨識、必要 status/hint 沒有消失，且不出現阻礙使用者完成核心流程的可讀性問題。
+
+## Out of Scope
+
+- 全域 toast、warning、dialog、status message 的全面統一重構。
+- 重新設計整個 extension 的提示命名、提示層級或回饋框架。
+- 刻意跟隨 VS Code host theme 的獨立頁面改版。
+- 將所有次要編輯輔助覆層列為本輪必修修正目標。
+- 與本輪主題一致性無關的全面視覺重設計。
+
+## Assumptions
+
+- 本次功能只聚焦於已確認的 editor-owned 主題 surface 一致性問題，不擴張成完整的提示系統治理專案。
+- 本輪若碰到既有提示元素，預設沿用原本提示角色，只做最小必要的可讀性與一致性調整。
+- 驗證主軸為 Blockly 編輯器的淺色與深色主題；高對比需求以 smoke-check 等級驗收為主。
+- 使用者在 TXT virtual controls 中設定的自訂顏色仍應被保留；本輪主要修正的是其周圍 editor-owned chrome。
+- 刻意 host-themed 的獨立頁面將維持現有設計，以避免把不同 owner 的介面混為同一輪變更。

--- a/specs/057-editor-theme-surface-consistency/tasks.md
+++ b/specs/057-editor-theme-surface-consistency/tasks.md
@@ -17,8 +17,8 @@
 
 **目的**：準備輕量驗證 scaffold，不改變產品行為。
 
-- [ ] T001 建立 quickstart 驗證矩陣標題與紀錄欄位於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
-- [ ] T002 [P] 建立 source-contract 檔案讀取與 allowlist 共用 helper 於 `src/test/suite/editorThemeSurfaceContractUtils.ts`
+- [X] T001 建立 quickstart 驗證矩陣標題與紀錄欄位於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [X] T002 [P] 建立 source-contract 檔案讀取與 allowlist 共用 helper 於 `src/test/suite/editorThemeSurfaceContractUtils.ts`
 
 ---
 
@@ -28,10 +28,10 @@
 
 **⚠️ 重要**：此 phase 完成前，不應開始任何 user story 實作。
 
-- [ ] T003 在 `media/css/blocklyEdit.css` 定義共享 editor-owned CSS custom properties，涵蓋 surface、field、card、notice、focus ring、scrollbar、description 與 warning
-- [ ] T004 [P] 在 `src/test/suite/editorThemeSurfaceContractUtils.ts` 編碼 host-token allowlist 規則，涵蓋高對比、focus ring、font token 與 standalone host-themed pages
-- [ ] T005 [P] 在 `src/test/webviewManager.test.ts` 補 WebView initial theme injection source-contract coverage，鎖定 `window.initialTheme` 與 `body.theme-{theme}`
-- [ ] T006 [P] 在 `src/test/suite/editorThemeSwitchContract.test.ts` 補 runtime theme switch source-contract coverage，鎖定 `updateTheme(theme)` 更新 body class、呼叫 Blockly `setTheme`，且不重設 `webview.html`
+- [X] T003 在 `media/css/blocklyEdit.css` 定義共享 editor-owned CSS custom properties，涵蓋 surface、field、card、notice、focus ring、scrollbar、description 與 warning
+- [X] T004 [P] 在 `src/test/suite/editorThemeSurfaceContractUtils.ts` 編碼 host-token allowlist 規則，涵蓋高對比、focus ring、font token 與 standalone host-themed pages
+- [X] T005 [P] 在 `src/test/webviewManager.test.ts` 補 WebView initial theme injection source-contract coverage，鎖定 `window.initialTheme` 與 `body.theme-{theme}`
+- [X] T006 [P] 在 `src/test/suite/editorThemeSwitchContract.test.ts` 補 runtime theme switch source-contract coverage，鎖定 `updateTheme(theme)` 更新 body class、呼叫 Blockly `setTheme`，且不重設 `webview.html`
 
 **Checkpoint**：Foundation ready；source-contract helper 與共享 editor-owned tokens 已存在。
 
@@ -47,17 +47,17 @@
 
 > 先撰寫這些測試，並在實作前確認它們會失敗。
 
-- [ ] T007 [P] [US1] 在 `src/test/suite/editorThemeSurfaceTxtModalContract.test.ts` 新增失敗中的 source-contract test，確認 TXT connection modal inputs 不含 inline `--vscode-input-*` styles
-- [ ] T008 [P] [US1] 在 `src/test/suite/editorThemeSurfaceSampleBrowserContract.test.ts` 新增失敗中的 source-contract test，確認 Sample Browser card、category、notice、loading 與 empty-state selectors 不使用 host base tokens
-- [ ] T009 [P] [US1] 在 `src/test/suite/editorThemeMainSurfaceSwitchContract.test.ts` 新增失敗中的 source-contract test，確認主要 editor surfaces 透過 runtime `updateTheme(theme)` 更新，且沒有 WebView reload 假設
+- [X] T007 [P] [US1] 在 `src/test/suite/editorThemeSurfaceTxtModalContract.test.ts` 新增失敗中的 source-contract test，確認 TXT connection modal inputs 不含 inline `--vscode-input-*` styles
+- [X] T008 [P] [US1] 在 `src/test/suite/editorThemeSurfaceSampleBrowserContract.test.ts` 新增失敗中的 source-contract test，確認 Sample Browser card、category、notice、loading 與 empty-state selectors 不使用 host base tokens
+- [X] T009 [P] [US1] 在 `src/test/suite/editorThemeMainSurfaceSwitchContract.test.ts` 新增失敗中的 source-contract test，確認主要 editor surfaces 透過 runtime `updateTheme(theme)` 更新，且沒有 WebView reload 假設
 
 ### User Story 1 實作任務
 
-- [ ] T010 [US1] 在 `media/html/blocklyEdit.html` 將 TXT connection input 的 inline host styles 改為可重用的 `txt-connection-input` class attributes
-- [ ] T011 [US1] 在 `media/css/blocklyEdit.css` 為 TXT connection modal 套用 editor-owned modal、label、input、hint、status 與 button styles
-- [ ] T012 [US1] 在 `media/css/blocklyEdit.css` 將 Sample Browser modal、category header、sample card、offline notice、loading、empty-state 與 action-button styles 改用 editor-owned tokens
-- [ ] T013 [US1] 在 `media/js/blocklyEdit.js` 確認 Sample Browser rendering 保留可 theme 的 card、description、button、spinner、offline notice 與 empty notice classes
-- [ ] T014 [US1] 在 `media/js/blocklyEdit.js` 確認 Extension Host theme update message 會呼叫 `updateTheme(theme)`，並在保持 open modal state、input value 與 scroll state 的情況下完成下一次 repaint 換色
+- [X] T010 [US1] 在 `media/html/blocklyEdit.html` 將 TXT connection input 的 inline host styles 改為可重用的 `txt-connection-input` class attributes
+- [X] T011 [US1] 在 `media/css/blocklyEdit.css` 為 TXT connection modal 套用 editor-owned modal、label、input、hint、status 與 button styles
+- [X] T012 [US1] 在 `media/css/blocklyEdit.css` 將 Sample Browser modal、category header、sample card、offline notice、loading、empty-state 與 action-button styles 改用 editor-owned tokens
+- [X] T013 [US1] 在 `media/js/blocklyEdit.js` 確認 Sample Browser rendering 保留可 theme 的 card、description、button、spinner、offline notice 與 empty notice classes
+- [X] T014 [US1] 在 `media/js/blocklyEdit.js` 確認 Extension Host theme update message 會呼叫 `updateTheme(theme)`，並在保持 open modal state、input value 與 scroll state 的情況下完成下一次 repaint 換色
 
 **Checkpoint**：User Story 1 可用相反 host/editor 主題獨立驗證 TXT modal 與 Sample Browser。
 
@@ -73,16 +73,16 @@
 
 > 先撰寫這些測試，並在實作前確認它們會失敗。
 
-- [ ] T015 [P] [US2] 在 `src/test/suite/editorThemeSurfaceTxtVirtualControlsContract.test.ts` 新增失敗中的 source-contract test，確認 TXT virtual controls base tokens 不由 `body.vscode-light` 或 `body.vscode-dark` 指派
-- [ ] T016 [P] [US2] 在 `src/test/suite/editorThemeTxtVirtualControlsSwitchContract.test.ts` 新增失敗中的 source-contract test，確認 TXT virtual controls theme-switch refresh 保留自訂 colors，且沒有 WebView reload 假設
+- [X] T015 [P] [US2] 在 `src/test/suite/editorThemeSurfaceTxtVirtualControlsContract.test.ts` 新增失敗中的 source-contract test，確認 TXT virtual controls base tokens 不由 `body.vscode-light` 或 `body.vscode-dark` 指派
+- [X] T016 [P] [US2] 在 `src/test/suite/editorThemeTxtVirtualControlsSwitchContract.test.ts` 新增失敗中的 source-contract test，確認 TXT virtual controls theme-switch refresh 保留自訂 colors，且沒有 WebView reload 假設
 
 ### User Story 2 實作任務
 
-- [ ] T017 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls base token assignments 從 `body.vscode-light` / `body.vscode-dark` 移到 `body.theme-light` / `body.theme-dark`
-- [ ] T018 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls panel、canvas、inspector、splitter、toolbar 與 mode badge chrome 改用共享 editor-owned tokens
-- [ ] T019 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls warning 與 invalid-reference chrome 的 host tokens 改為 editor-owned warning tokens，同時保留 allowlisted contrast rings
-- [ ] T020 [US2] 在 `media/js/txtVirtualControlsContrast.js` 更新 TXT virtual controls contrast fallback logic，讓 editor-owned defaults 優先使用 `theme-dark` 而不是 `vscode-dark`
-- [ ] T021 [US2] 在 `media/js/blocklyEdit.js` 確認 `updateTheme(theme)` 會 refresh TXT virtual controls UI，且不覆蓋使用者自訂 colors
+- [X] T017 [US2] 在 `media/css/blocklyEdit.css` 移除 TXT virtual controls token assignments 對 `body.vscode-light` / `body.vscode-dark` 的依賴，改由 `body.theme-light` / `body.theme-dark` 與 high-contrast exceptions 定義
+- [X] T018 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls panel/canvas/inspector/splitter/toolbar/mode badge chrome 改用 editor-owned tokens 或 `--txt-virtual-controls-*` tokens
+- [X] T019 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls warning/invalid-reference chrome 從 host input validation/list/badge base tokens 改成 editor-owned warning/status tokens，保留 high-contrast ring 可讀性
+- [X] T020 [US2] 在 `media/js/txtVirtualControlsContrast.js` 確認 fallback/default style 判斷優先使用 `theme-light` / `theme-dark` 而非 `vscode-dark`
+- [X] T021 [US2] 在 `media/js/blocklyEdit.js` 確認 `updateTheme(theme)` 會 refresh TXT virtual controls UI 且不重設使用者自訂 control colors
 
 **Checkpoint**：User Story 2 可用相反 host/editor 主題獨立驗證 TXT virtual controls。
 
@@ -98,15 +98,15 @@
 
 > 先撰寫這些測試，並在實作前確認它們會失敗。
 
-- [ ] T022 [P] [US3] 在 `src/test/suite/editorThemeTouchedFeedbackContract.test.ts` 新增失敗中的 source-contract test，檢查 touched feedback 的低對比 leakage 與禁止的固定 `#888` patterns
-- [ ] T023 [P] [US3] 在 `src/test/suite/editorThemeTouchedFeedbackI18nContract.test.ts` 新增失敗中的 source-contract test，確認 touched feedback visible text 維持不變，或有 locale keys 支援
+- [X] T022 [P] [US3] 在 `src/test/suite/editorThemeTouchedFeedbackContract.test.ts` 新增失敗中的 source-contract test，檢查 touched feedback 的低對比 leakage 與禁止的固定 `#888` patterns
+- [X] T023 [P] [US3] 在 `src/test/suite/editorThemeTouchedFeedbackI18nContract.test.ts` 新增失敗中的 source-contract test，確認 touched feedback visible text 維持不變，或有 locale keys 支援
 
 ### User Story 3 實作任務
 
-- [ ] T024 [US3] 在 `media/css/blocklyEdit.css` 將 editor-owned description、notice、loading、status 與 empty-state tokens 套用到 TXT SSH hint 與 Sample Browser feedback
-- [ ] T025 [US3] 在 `media/css/blocklyEdit.css` 將 editor-owned hint、empty-state、warning 與 invalid-reference tokens 套用到 TXT virtual controls feedback surfaces
-- [ ] T026 [US3] 在 `media/html/blocklyEdit.html` 保留既有 visible text，只調整 touched feedback 的 class/style ownership
-- [ ] T027 [US3] 在 `media/js/blocklyEdit.js` 保留既有 visible text 與 locale-key usage，只更新 touched feedback rendering classes
+- [X] T024 [US3] 在 `media/css/blocklyEdit.css` 將 editor-owned description、notice、loading、status 與 empty-state tokens 套用到 TXT SSH hint 與 Sample Browser feedback
+- [X] T025 [US3] 在 `media/css/blocklyEdit.css` 將 editor-owned hint、empty-state、warning 與 invalid-reference tokens 套用到 TXT virtual controls feedback surfaces
+- [X] T026 [US3] 在 `media/html/blocklyEdit.html` 保留既有 visible text，只調整 touched feedback 的 class/style ownership
+- [X] T027 [US3] 在 `media/js/blocklyEdit.js` 保留既有 visible text 與 locale-key usage，只更新 touched feedback rendering classes
 
 **Checkpoint**：User Story 3 可用既有 feedback roles 與可讀 touched hints/notices/status text 獨立驗證。
 
@@ -122,12 +122,12 @@
 
 > 先撰寫這些測試，並在實作前確認它們會失敗。
 
-- [ ] T028 [P] [US4] 在 `src/test/suite/editorThemeHighContrastContract.test.ts` 新增失敗中的 source-contract test，確認 high-contrast、focus、font 與 contrast token usages 符合明確 allowlist
+- [X] T028 [P] [US4] 在 `src/test/suite/editorThemeHighContrastContract.test.ts` 新增失敗中的 source-contract test，確認 high-contrast、focus、font 與 contrast token usages 符合明確 allowlist
 
 ### User Story 4 實作任務
 
-- [ ] T029 [US4] 在 `media/css/blocklyEdit.css` 新增或保留 TXT modal、Sample Browser 與 TXT virtual controls editor-owned tokens 的 high-contrast 與 forced-colors overrides
-- [ ] T030 [US4] 在 `specs/057-editor-theme-surface-consistency/manual-validation.md` 記錄 M5 high-contrast smoke-check 結果、截圖或備註，並逐項確認文字、邊界、focus ring、主要按鈕與必要 status/hint
+- [X] T029 [US4] 在 `media/css/blocklyEdit.css` 新增或保留 TXT modal、Sample Browser 與 TXT virtual controls editor-owned tokens 的 high-contrast 與 forced-colors overrides
+- [X] T030 [US4] 在 `specs/057-editor-theme-surface-consistency/manual-validation.md` 記錄 M5 high-contrast smoke-check 結果、截圖或備註，並逐項確認文字、邊界、focus ring、主要按鈕與必要 status/hint
 
 **Checkpoint**：User Story 4 可用高對比 smoke-check evidence 獨立驗證。
 
@@ -137,13 +137,13 @@
 
 **目的**：完成跨 stories 的最終驗證、文件紀錄與回歸檢查。
 
-- [ ] T031 [P] 執行 compile、lint 與 source-contract test verification，並將 command results 記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
-- [ ] T032 [P] 執行 i18n validation，或在沒有 visible text 變更時將原因記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
-- [ ] T033 依 quickstart 執行 M1-M4 manual light/dark matrix，並將 pass/fail notes 記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
-- [ ] T034 [P] 檢查 `media/css/platformioDiagnostic.css` 仍維持 standalone host-themed exception，並將排除理由記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
-- [ ] T035 [P] 若本輪實作觸及 `media/css/shadowBlock.css` 或相關 secondary overlay 檔案，則補上 editor-theme/即時更新修正或在 `specs/057-editor-theme-surface-consistency/manual-validation.md` 明確記錄刻意例外
-- [ ] T036 [P] 從 `media/css/blocklyEdit.css` 移除最終 touched editor files 中的暫時 debugging styles 或 comments
-- [ ] T037 [P] 從 `media/html/blocklyEdit.html` 移除最終 touched editor markup 中的暫時 debugging attributes 或 comments
+- [X] T031 [P] 執行 compile、lint 與 source-contract test verification，並將 command results 記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [X] T032 [P] 執行 i18n validation，或在沒有 visible text 變更時將原因記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [X] T033 依 quickstart 執行 M1-M4 manual light/dark matrix，並將 pass/fail notes 記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`（本次 headless session 記錄為自動化通過、互動式畫面需人工複核）
+- [X] T034 [P] 檢查 `media/css/platformioDiagnostic.css` 仍維持 standalone host-themed exception，並將排除理由記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [X] T035 [P] 若本輪實作觸及 `media/css/shadowBlock.css` 或相關 secondary overlay 檔案，則補上 editor-theme/即時更新修正或在 `specs/057-editor-theme-surface-consistency/manual-validation.md` 明確記錄刻意例外
+- [X] T036 [P] 從 `media/css/blocklyEdit.css` 移除最終 touched editor files 中的暫時 debugging styles 或 comments
+- [X] T037 [P] 從 `media/html/blocklyEdit.html` 移除最終 touched editor markup 中的暫時 debugging attributes 或 comments
 
 ---
 

--- a/specs/057-editor-theme-surface-consistency/tasks.md
+++ b/specs/057-editor-theme-surface-consistency/tasks.md
@@ -1,0 +1,249 @@
+# Tasks: 編輯器主題 surface 一致性
+
+**輸入**：來自 `/specs/057-editor-theme-surface-consistency/` 的設計文件  
+**前置文件**：`plan.md`（必要）、`spec.md`（必要）、`research.md`、`data-model.md`、`contracts/`、`quickstart.md`
+
+**測試策略**：包含測試任務。此功能的 plan 與 contracts 已明確要求 source-contract tests，用來鎖定 HTML/CSS 主題 ownership、即時主題切換、高對比 allowlist 與 touched feedback 規則。每個故事的測試任務必須先撰寫，並在實作前確認會失敗。
+
+**組織方式**：任務依 user story 分組，讓每個故事都能獨立實作與驗證。
+
+## 格式：`[ID] [P?] [Story] 任務描述`
+
+- **[P]**：可平行執行；代表該任務碰觸不同檔案，且不依賴尚未完成的任務。
+- **[Story]**：user story 標籤（`US1`、`US2`、`US3`、`US4`），僅用於 story phases。
+- 每個任務描述都必須包含明確的 workspace-relative 檔案路徑。
+
+## Phase 1: Setup（共享基礎設施）
+
+**目的**：準備輕量驗證 scaffold，不改變產品行為。
+
+- [ ] T001 建立 quickstart 驗證矩陣標題與紀錄欄位於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [ ] T002 [P] 建立 source-contract 檔案讀取與 allowlist 共用 helper 於 `src/test/suite/editorThemeSurfaceContractUtils.ts`
+
+---
+
+## Phase 2: Foundational（阻塞性前置任務）
+
+**目的**：建立所有 user stories 都會依賴的 editor-owned token 與共用契約基礎。
+
+**⚠️ 重要**：此 phase 完成前，不應開始任何 user story 實作。
+
+- [ ] T003 在 `media/css/blocklyEdit.css` 定義共享 editor-owned CSS custom properties，涵蓋 surface、field、card、notice、focus ring、scrollbar、description 與 warning
+- [ ] T004 [P] 在 `src/test/suite/editorThemeSurfaceContractUtils.ts` 編碼 host-token allowlist 規則，涵蓋高對比、focus ring、font token 與 standalone host-themed pages
+- [ ] T005 [P] 在 `src/test/webviewManager.test.ts` 補 WebView initial theme injection source-contract coverage，鎖定 `window.initialTheme` 與 `body.theme-{theme}`
+- [ ] T006 [P] 在 `src/test/suite/editorThemeSwitchContract.test.ts` 補 runtime theme switch source-contract coverage，鎖定 `updateTheme(theme)` 更新 body class、呼叫 Blockly `setTheme`，且不重設 `webview.html`
+
+**Checkpoint**：Foundation ready；source-contract helper 與共享 editor-owned tokens 已存在。
+
+---
+
+## Phase 3: User Story 1 - 主要編輯器視窗在交錯主題下仍保持一致（Priority: P1）🎯 MVP
+
+**目標**：TXT connection modal 與 Sample Browser 必須跟隨 Blockly editor theme，而不是 VS Code host theme；即使 host/editor 使用相反 light/dark 主題也一致。
+
+**獨立驗證**：將 VS Code 與 Blockly editor 設為相反 light/dark 主題，開啟 TXT connection modal 與 Sample Browser，確認兩者使用 editor theme；在視窗保持開啟時切換 editor theme，確認 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 即換色，且不 reload、不重開、不清空輸入內容。
+
+### User Story 1 測試任務
+
+> 先撰寫這些測試，並在實作前確認它們會失敗。
+
+- [ ] T007 [P] [US1] 在 `src/test/suite/editorThemeSurfaceTxtModalContract.test.ts` 新增失敗中的 source-contract test，確認 TXT connection modal inputs 不含 inline `--vscode-input-*` styles
+- [ ] T008 [P] [US1] 在 `src/test/suite/editorThemeSurfaceSampleBrowserContract.test.ts` 新增失敗中的 source-contract test，確認 Sample Browser card、category、notice、loading 與 empty-state selectors 不使用 host base tokens
+- [ ] T009 [P] [US1] 在 `src/test/suite/editorThemeMainSurfaceSwitchContract.test.ts` 新增失敗中的 source-contract test，確認主要 editor surfaces 透過 runtime `updateTheme(theme)` 更新，且沒有 WebView reload 假設
+
+### User Story 1 實作任務
+
+- [ ] T010 [US1] 在 `media/html/blocklyEdit.html` 將 TXT connection input 的 inline host styles 改為可重用的 `txt-connection-input` class attributes
+- [ ] T011 [US1] 在 `media/css/blocklyEdit.css` 為 TXT connection modal 套用 editor-owned modal、label、input、hint、status 與 button styles
+- [ ] T012 [US1] 在 `media/css/blocklyEdit.css` 將 Sample Browser modal、category header、sample card、offline notice、loading、empty-state 與 action-button styles 改用 editor-owned tokens
+- [ ] T013 [US1] 在 `media/js/blocklyEdit.js` 確認 Sample Browser rendering 保留可 theme 的 card、description、button、spinner、offline notice 與 empty notice classes
+- [ ] T014 [US1] 在 `media/js/blocklyEdit.js` 確認 Extension Host theme update message 會呼叫 `updateTheme(theme)`，並在保持 open modal state、input value 與 scroll state 的情況下完成下一次 repaint 換色
+
+**Checkpoint**：User Story 1 可用相反 host/editor 主題獨立驗證 TXT modal 與 Sample Browser。
+
+---
+
+## Phase 4: User Story 2 - 編輯器控制面與外框維持單一主題 owner（Priority: P1）
+
+**目標**：TXT virtual controls chrome 使用 editor-owned tokens，同時保留使用者自訂 control colors。
+
+**獨立驗證**：在相反 host/editor 主題下開啟 TXT virtual controls，確認 panel/canvas/inspector/chrome 跟隨 editor theme；保持 controls 開啟並切換 editor theme，確認 `updateTheme(theme)` 完成後下一次瀏覽器 repaint 即換色，且自訂 control colors 不被覆蓋。
+
+### User Story 2 測試任務
+
+> 先撰寫這些測試，並在實作前確認它們會失敗。
+
+- [ ] T015 [P] [US2] 在 `src/test/suite/editorThemeSurfaceTxtVirtualControlsContract.test.ts` 新增失敗中的 source-contract test，確認 TXT virtual controls base tokens 不由 `body.vscode-light` 或 `body.vscode-dark` 指派
+- [ ] T016 [P] [US2] 在 `src/test/suite/editorThemeTxtVirtualControlsSwitchContract.test.ts` 新增失敗中的 source-contract test，確認 TXT virtual controls theme-switch refresh 保留自訂 colors，且沒有 WebView reload 假設
+
+### User Story 2 實作任務
+
+- [ ] T017 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls base token assignments 從 `body.vscode-light` / `body.vscode-dark` 移到 `body.theme-light` / `body.theme-dark`
+- [ ] T018 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls panel、canvas、inspector、splitter、toolbar 與 mode badge chrome 改用共享 editor-owned tokens
+- [ ] T019 [US2] 在 `media/css/blocklyEdit.css` 將 TXT virtual controls warning 與 invalid-reference chrome 的 host tokens 改為 editor-owned warning tokens，同時保留 allowlisted contrast rings
+- [ ] T020 [US2] 在 `media/js/txtVirtualControlsContrast.js` 更新 TXT virtual controls contrast fallback logic，讓 editor-owned defaults 優先使用 `theme-dark` 而不是 `vscode-dark`
+- [ ] T021 [US2] 在 `media/js/blocklyEdit.js` 確認 `updateTheme(theme)` 會 refresh TXT virtual controls UI，且不覆蓋使用者自訂 colors
+
+**Checkpoint**：User Story 2 可用相反 host/editor 主題獨立驗證 TXT virtual controls。
+
+---
+
+## Phase 5: User Story 3 - 本輪觸及到的提示維持原意且更容易看懂（Priority: P2）
+
+**目標**：本輪 touched hints、notices、status text 與 warnings 保留既有角色，同時在 editor light/dark 主題下都可讀。
+
+**獨立驗證**：在 TXT modal、Sample Browser 與 TXT virtual controls 中觸發本輪 touched feedback，確認每個 element 保留原角色、關鍵資訊不是 hover-only，且在 editor light/dark 下清楚可讀。
+
+### User Story 3 測試任務
+
+> 先撰寫這些測試，並在實作前確認它們會失敗。
+
+- [ ] T022 [P] [US3] 在 `src/test/suite/editorThemeTouchedFeedbackContract.test.ts` 新增失敗中的 source-contract test，檢查 touched feedback 的低對比 leakage 與禁止的固定 `#888` patterns
+- [ ] T023 [P] [US3] 在 `src/test/suite/editorThemeTouchedFeedbackI18nContract.test.ts` 新增失敗中的 source-contract test，確認 touched feedback visible text 維持不變，或有 locale keys 支援
+
+### User Story 3 實作任務
+
+- [ ] T024 [US3] 在 `media/css/blocklyEdit.css` 將 editor-owned description、notice、loading、status 與 empty-state tokens 套用到 TXT SSH hint 與 Sample Browser feedback
+- [ ] T025 [US3] 在 `media/css/blocklyEdit.css` 將 editor-owned hint、empty-state、warning 與 invalid-reference tokens 套用到 TXT virtual controls feedback surfaces
+- [ ] T026 [US3] 在 `media/html/blocklyEdit.html` 保留既有 visible text，只調整 touched feedback 的 class/style ownership
+- [ ] T027 [US3] 在 `media/js/blocklyEdit.js` 保留既有 visible text 與 locale-key usage，只更新 touched feedback rendering classes
+
+**Checkpoint**：User Story 3 可用既有 feedback roles 與可讀 touched hints/notices/status text 獨立驗證。
+
+---
+
+## Phase 6: User Story 4 - 在高對比與交錯主題情境下仍可完成核心操作（Priority: P3）
+
+**目標**：P1 surfaces 在高對比 smoke check 與所有必要 light/dark host/editor 組合下仍可用。
+
+**獨立驗證**：執行 quickstart 的高對比 smoke check 與四組 light/dark matrix；高對比通過標準為主要文字可讀、input/card/panel 邊界可辨識、focus ring 可見、主要操作按鈕可辨識、必要 status/hint 沒有消失，且不需要切回相同 host/editor 主題才能完成核心操作。
+
+### User Story 4 測試任務
+
+> 先撰寫這些測試，並在實作前確認它們會失敗。
+
+- [ ] T028 [P] [US4] 在 `src/test/suite/editorThemeHighContrastContract.test.ts` 新增失敗中的 source-contract test，確認 high-contrast、focus、font 與 contrast token usages 符合明確 allowlist
+
+### User Story 4 實作任務
+
+- [ ] T029 [US4] 在 `media/css/blocklyEdit.css` 新增或保留 TXT modal、Sample Browser 與 TXT virtual controls editor-owned tokens 的 high-contrast 與 forced-colors overrides
+- [ ] T030 [US4] 在 `specs/057-editor-theme-surface-consistency/manual-validation.md` 記錄 M5 high-contrast smoke-check 結果、截圖或備註，並逐項確認文字、邊界、focus ring、主要按鈕與必要 status/hint
+
+**Checkpoint**：User Story 4 可用高對比 smoke-check evidence 獨立驗證。
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**目的**：完成跨 stories 的最終驗證、文件紀錄與回歸檢查。
+
+- [ ] T031 [P] 執行 compile、lint 與 source-contract test verification，並將 command results 記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [ ] T032 [P] 執行 i18n validation，或在沒有 visible text 變更時將原因記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [ ] T033 依 quickstart 執行 M1-M4 manual light/dark matrix，並將 pass/fail notes 記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [ ] T034 [P] 檢查 `media/css/platformioDiagnostic.css` 仍維持 standalone host-themed exception，並將排除理由記錄於 `specs/057-editor-theme-surface-consistency/manual-validation.md`
+- [ ] T035 [P] 若本輪實作觸及 `media/css/shadowBlock.css` 或相關 secondary overlay 檔案，則補上 editor-theme/即時更新修正或在 `specs/057-editor-theme-surface-consistency/manual-validation.md` 明確記錄刻意例外
+- [ ] T036 [P] 從 `media/css/blocklyEdit.css` 移除最終 touched editor files 中的暫時 debugging styles 或 comments
+- [ ] T037 [P] 從 `media/html/blocklyEdit.html` 移除最終 touched editor markup 中的暫時 debugging attributes 或 comments
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup（Phase 1）**：沒有依賴，可立即開始。
+- **Foundational（Phase 2）**：依賴 Setup 完成；會阻塞所有 user stories。
+- **User Stories（Phase 3+）**：依賴 Foundational 完成。
+  - **US1 與 US2 都是 P1**，Foundation 完成後可平行推進，但若多人同時修改 `media/css/blocklyEdit.css` 必須協調合併。
+  - **US3（P2）** 依賴 US1/US2 相關 touched feedback selectors 穩定後開始，但仍可透過 feedback contract 獨立驗證。
+  - **US4（P3）** 依賴 P1 token structure 與 high-contrast allowlist rules。
+- **Polish（Phase 7）**：依賴欲交付的 user stories 完成。
+
+### User Story Dependencies
+
+- **US1（P1）**：Phase 2 後可開始；不依賴 US2、US3 或 US4。
+- **US2（P1）**：Phase 2 後可開始；不依賴 US1、US3 或 US4，但需協調 `media/css/blocklyEdit.css` merge conflicts。
+- **US3（P2）**：US1 和/或 US2 的 touched feedback selectors 存在後開始；不得改變 feedback role 或 text，除非同步 locale-backed 更新。
+- **US4（P3）**：US1 與 US2 token changes 後開始；驗證 accessibility/high-contrast exceptions。
+
+### 每個 User Story 內部順序
+
+- 先寫測試，並在實作前確認測試會失敗。
+- 同時需要 CSS/HTML 與 JS 時，先完成 CSS/HTML ownership changes，再檢查 JS refresh flow。
+- 除非明確新增 locale-backed 文字，否則保留 user-visible text 不變。
+- 每個 story 完成 checkpoint 後，再移往下一個 priority。
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1
+
+```text
+Task: T007 TXT modal inline host-token contract test in src/test/suite/editorThemeSurfaceTxtModalContract.test.ts
+Task: T008 Sample Browser host-token contract test in src/test/suite/editorThemeSurfaceSampleBrowserContract.test.ts
+Task: T009 Main surface theme-switch contract test in src/test/suite/editorThemeMainSurfaceSwitchContract.test.ts
+```
+
+### User Story 2
+
+```text
+Task: T015 TXT virtual controls host-theme leakage contract test in src/test/suite/editorThemeSurfaceTxtVirtualControlsContract.test.ts
+Task: T016 TXT virtual controls theme-switch contract test in src/test/suite/editorThemeTxtVirtualControlsSwitchContract.test.ts
+```
+
+### User Story 3
+
+```text
+Task: T022 Touched feedback color leakage contract test in src/test/suite/editorThemeTouchedFeedbackContract.test.ts
+Task: T023 Touched feedback i18n guard contract test in src/test/suite/editorThemeTouchedFeedbackI18nContract.test.ts
+```
+
+### User Story 4
+
+```text
+Task: T028 High-contrast allowlist contract test in src/test/suite/editorThemeHighContrastContract.test.ts
+Task: T030 High-contrast manual evidence in specs/057-editor-theme-surface-consistency/manual-validation.md
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First（只做 User Story 1）
+
+1. 完成 Phase 1 Setup。
+2. 完成 Phase 2 Foundational token 與 contract helper 工作。
+3. 完成 Phase 3 User Story 1。
+4. 停下來驗證相反 host/editor 主題下的 TXT connection modal 與 Sample Browser。
+5. MVP 可 demo/review 後，再擴展到 TXT virtual controls。
+
+### Incremental Delivery
+
+1. Setup + Foundation 建立 editor-owned tokens 與共享 contract helpers。
+2. US1 修正主要 modal/browser surfaces，交付可見 MVP。
+3. US2 將相同 ownership 規則延伸到 TXT virtual controls chrome。
+4. US3 強化 touched feedback readability，但不建立新的 feedback framework。
+5. US4 驗證 high-contrast 與完整 matrix behavior。
+6. Polish 記錄自動化與手動驗證 evidence。
+
+### Parallel Team Strategy
+
+多人協作時：
+
+1. 一位開發者先完成 setup 與 contract helper scaffolding。
+2. Foundation 完成後：
+   - Developer A：US1 HTML/CSS 與 Sample Browser contracts。
+   - Developer B：US2 TXT virtual controls CSS/JS contracts。
+   - Developer C：在相關 selectors 穩定後處理 US3 feedback contracts。
+3. 因為 US1、US2、US3、US4 都會碰到 `media/css/blocklyEdit.css`，需要小心協調 CSS edits。
+
+---
+
+## Notes
+
+- `[P]` tasks 代表碰觸不同檔案，或是可獨立執行的驗證/紀錄任務。
+- Source-contract tests 應採輕量 file-content checks，因為 WebView browser code 不能直接 import 到 Node.js tests。
+- `media/css/platformioDiagnostic.css` 是明確 standalone host-themed exception，本功能不應轉成 editor-owned tokens。
+- `media/css/shadowBlock.css` 是 opportunistic；只有本輪實作實際觸及時，才依 T035 套用相同 editor-theme 與 immediate-update 規則或記錄例外。
+- 使用 git workflow 時，建議每完成一個 story 或 logical group 後提交一次。

--- a/src/test/suite/editorThemeBackupPreviewContract.test.ts
+++ b/src/test/suite/editorThemeBackupPreviewContract.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import {
+	assertNoWebViewReloadAntipatterns,
+	assertNoPatterns,
+	collectCssRuleBlocks,
+	extractSourceBetween,
+	readWorkspaceFile,
+} from './editorThemeSurfaceContractUtils';
+
+const PREVIEW_CHROME_SELECTOR_PATTERNS = [
+	/\.preview-info\b/,
+	/\.preview-controls\b/,
+	/\.preview-badge\b/,
+	/\.preview-blockly-area\b/,
+	/\.board-warning\b/,
+];
+
+const PREVIEW_CHROME_FIXED_THEME_PATTERNS = [
+	/background(?:-color)?\s*:\s*rgba\(\s*255\s*,\s*255\s*,\s*255/i,
+	/background(?:-color)?\s*:\s*rgba\(\s*50\s*,\s*50\s*,\s*50/i,
+	/(?:background(?:-color)?|color|border(?:-color)?)\s*:\s*#(?:333|444444|555555|f0f0f0|e0e0e0|3f51b5|5c6bc0|ffc107|212529|e0a800)\b/i,
+];
+
+describe('Editor theme backup preview contract', () => {
+	it('initializes backup preview with editor theme ownership classes, not VS Code host theme classes', () => {
+		const html = readWorkspaceFile('media/html/blocklyPreview.html');
+		const bodyTag = html.match(/<body\b[^>]*>/i)?.[0] || '';
+		assert(bodyTag, 'backup preview body tag must exist');
+		assert.match(bodyTag, /class=["'][^"']*theme-\{theme\}[^"']*preview-mode[^"']*["']/);
+		assertNoPatterns(bodyTag, [/vscode-(?:light|dark|high-contrast)/i], 'backup preview body tag');
+	});
+
+	it('keeps backup preview chrome and board warnings on editor-owned tokens', () => {
+		const css = readWorkspaceFile('media/css/blocklyEdit.css');
+		const previewChromeBlocks = collectCssRuleBlocks(css, PREVIEW_CHROME_SELECTOR_PATTERNS);
+
+		assertNoPatterns(previewChromeBlocks, PREVIEW_CHROME_FIXED_THEME_PATTERNS, 'backup preview chrome styles');
+		assert.match(previewChromeBlocks, /\.preview-info\s*\{[\s\S]*background-color\s*:\s*var\(--editor-card-bg\)/);
+		assert.match(previewChromeBlocks, /\.preview-info\s*\{[\s\S]*color\s*:\s*var\(--editor-card-fg\)/);
+		assert.match(previewChromeBlocks, /\.preview-controls\s*\{[\s\S]*background-color\s*:\s*var\(--editor-card-bg\)/);
+		assert.match(previewChromeBlocks, /\.preview-badge\s*\{[\s\S]*background-color\s*:\s*var\(--editor-notice-bg\)/);
+		assert.match(previewChromeBlocks, /\.board-warning\s*\{[\s\S]*background-color\s*:\s*var\(--editor-warning-bg\)/);
+	});
+
+	it('renders preview board warnings through CSS classes instead of inline fixed colors', () => {
+		const source = readWorkspaceFile('media/js/blocklyPreview.js');
+		assert(source.includes("warningEl.className = 'board-warning';"));
+		assert(!/warningEl\.style\.cssText/.test(source), 'backup preview board warnings must not use inline fixed-color styles');
+	});
+
+	it('updates backup preview theme at runtime without reload assumptions', () => {
+		const source = readWorkspaceFile('media/js/blocklyPreview.js');
+		const updateThemeBody = extractSourceBetween(
+			source,
+			'function updateTheme(theme',
+			'/**\n * 從工作區狀態',
+			'blocklyPreview.js updateTheme(theme) contract slice'
+		);
+
+		assert(updateThemeBody.includes("document.body.classList.remove('theme-light', 'theme-dark')"));
+		assert(updateThemeBody.includes('document.body.classList.add(`theme-${theme}`)'));
+		assert(updateThemeBody.includes('workspace.setTheme(blocklyTheme)'));
+		assert(updateThemeBody.includes('renderTxtPreviewControls()'));
+		assertNoWebViewReloadAntipatterns(updateThemeBody, 'backup preview updateTheme(theme)');
+	});
+});

--- a/src/test/suite/editorThemeHighContrastContract.test.ts
+++ b/src/test/suite/editorThemeHighContrastContract.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import {
+	findDisallowedHostTokens,
+	readWorkspaceFile,
+	stripCssComments,
+} from './editorThemeSurfaceContractUtils';
+
+const REQUIRED_FORCED_COLORS_SELECTORS = [
+	'.preview-info',
+	'.preview-controls',
+	'.preview-controls #themeToggle',
+	'.preview-badge',
+	'.board-warning',
+	'.txt-connection-modal-content',
+	'.txt-connection-input',
+	'.sample-card',
+	'.sample-offline-notice',
+	'.sample-empty-notice',
+	'.txt-virtual-controls-panel',
+	'.txt-preview-canvas',
+	'.txt-virtual-controls-mode-badge',
+	'.txt-virtual-control-button',
+];
+
+describe('Editor theme high contrast contract', () => {
+	it('keeps host theme tokens limited to focus, font, and high-contrast allowlist usage', () => {
+		const css = readWorkspaceFile('media/css/blocklyEdit.css');
+		const cssWithoutComments = stripCssComments(css);
+		const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+		const disallowedUsages: string[] = [];
+		let match: RegExpExecArray | null;
+
+		while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+			const block = `${match[1].trim()} {${match[2]}}`;
+			const tokens = findDisallowedHostTokens(block, { filePath: 'media/css/blocklyEdit.css', sourceContext: block });
+			if (tokens.length > 0) {
+				disallowedUsages.push(`${match[1].trim()}: ${tokens.join(', ')}`);
+			}
+		}
+
+		assert.deepStrictEqual(disallowedUsages, []);
+	});
+
+	it('covers P1 editor-owned surfaces in forced-colors overrides', () => {
+		const css = stripCssComments(readWorkspaceFile('media/css/blocklyEdit.css'));
+		const forcedColorsStart = css.indexOf('@media (forced-colors: active)');
+		const forcedColorsEnd = css.indexOf('\n#themeToggle', forcedColorsStart);
+		assert(forcedColorsStart >= 0 && forcedColorsEnd > forcedColorsStart, 'forced-colors override block must exist before toolbar styles');
+		const forcedColorsBlock = css.slice(forcedColorsStart, forcedColorsEnd);
+
+		for (const selector of REQUIRED_FORCED_COLORS_SELECTORS) {
+			assert(
+				forcedColorsBlock.includes(selector),
+				`forced-colors overrides must include ${selector}`
+			);
+		}
+	});
+});

--- a/src/test/suite/editorThemeHighContrastContract.test.ts
+++ b/src/test/suite/editorThemeHighContrastContract.test.ts
@@ -7,6 +7,8 @@
 import assert = require('assert');
 import { describe, it } from 'mocha';
 import {
+	collectCssRuleBlocks,
+	extractBalancedCssBlock,
 	findDisallowedHostTokens,
 	readWorkspaceFile,
 	stripCssComments,
@@ -49,11 +51,11 @@ describe('Editor theme high contrast contract', () => {
 	});
 
 	it('covers P1 editor-owned surfaces in forced-colors overrides', () => {
-		const css = stripCssComments(readWorkspaceFile('media/css/blocklyEdit.css'));
-		const forcedColorsStart = css.indexOf('@media (forced-colors: active)');
-		const forcedColorsEnd = css.indexOf('\n#themeToggle', forcedColorsStart);
-		assert(forcedColorsStart >= 0 && forcedColorsEnd > forcedColorsStart, 'forced-colors override block must exist before toolbar styles');
-		const forcedColorsBlock = css.slice(forcedColorsStart, forcedColorsEnd);
+		const forcedColorsBlock = extractBalancedCssBlock(
+			readWorkspaceFile('media/css/blocklyEdit.css'),
+			/@media\s*\(\s*forced-colors\s*:\s*active\s*\)/,
+			'forced-colors override block'
+		);
 
 		for (const selector of REQUIRED_FORCED_COLORS_SELECTORS) {
 			assert(
@@ -61,5 +63,16 @@ describe('Editor theme high contrast contract', () => {
 				`forced-colors overrides must include ${selector}`
 			);
 		}
+	});
+
+	it('keeps TXT virtual controls running badge readable in VS Code high contrast themes', () => {
+		const css = readWorkspaceFile('media/css/blocklyEdit.css');
+		const runningBadgeBlocks = collectCssRuleBlocks(css, [
+			/body\.vscode-high-contrast(?:-light)?\s+\.txt-virtual-controls-mode-badge\.running/,
+		]);
+
+		assert.match(runningBadgeBlocks, /background\s*:\s*Highlight\b/);
+		assert.match(runningBadgeBlocks, /color\s*:\s*HighlightText\b/);
+		assert.match(runningBadgeBlocks, /border-color\s*:\s*Highlight\b/);
 	});
 });

--- a/src/test/suite/editorThemeMainSurfaceSwitchContract.test.ts
+++ b/src/test/suite/editorThemeMainSurfaceSwitchContract.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import { assertNoWebViewReloadAntipatterns, readWorkspaceFile } from './editorThemeSurfaceContractUtils';
+
+describe('Editor theme main surface switch contract', () => {
+	it('handles Extension Host updateTheme messages through the same runtime updateTheme path', () => {
+		const source = readWorkspaceFile('media/js/blocklyEdit.js');
+		const listenerStart = source.indexOf("window.addEventListener('message'");
+		assert(listenerStart >= 0, 'blocklyEdit.js should listen for Extension Host messages');
+		const listenerSource = source.slice(listenerStart);
+
+		assert(listenerSource.includes("case 'updateTheme':"), 'Extension Host updateTheme messages should be handled in the WebView');
+		assert(listenerSource.includes('updateTheme(currentTheme)'), 'Theme messages should call updateTheme(currentTheme)');
+		assertNoWebViewReloadAntipatterns(listenerSource, 'blocklyEdit.js message listener');
+	});
+
+	it('keeps loadWorkspace theme updates as a runtime body-class update, not a reload assumption', () => {
+		const source = readWorkspaceFile('media/js/blocklyEdit.js');
+		const loadWorkspaceStart = source.indexOf('const handleWorkspaceLoadMessage = async message =>');
+		const listenerStart = source.indexOf("window.addEventListener('message'", loadWorkspaceStart);
+		assert(loadWorkspaceStart >= 0, 'blocklyEdit.js should define handleWorkspaceLoadMessage');
+		assert(listenerStart > loadWorkspaceStart, 'message listener should appear after handleWorkspaceLoadMessage');
+		const loadWorkspaceSource = source.slice(loadWorkspaceStart, listenerStart);
+
+		assert(loadWorkspaceSource.includes('updateTheme(currentTheme)'));
+		assertNoWebViewReloadAntipatterns(loadWorkspaceSource, 'blocklyEdit.js loadWorkspace handler');
+	});
+});

--- a/src/test/suite/editorThemeSurfaceContractUtils.ts
+++ b/src/test/suite/editorThemeSurfaceContractUtils.ts
@@ -35,10 +35,6 @@ export function stripCssComments(source: string): string {
 	return source.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
-export function stripHtmlComments(source: string): string {
-	return source.replace(/<!--[\s\S]*?-->/g, '');
-}
-
 export function normalizeWhitespace(source: string): string {
 	return source.replace(/\s+/g, ' ').trim();
 }
@@ -49,7 +45,7 @@ export function escapeRegExp(value: string): string {
 
 export function getHtmlElementTag(source: string, id: string): string {
 	const pattern = new RegExp(`<[^>]+\\bid=["']${escapeRegExp(id)}["'][^>]*>`, 'i');
-	const match = stripHtmlComments(source).match(pattern);
+	const match = source.match(pattern);
 	if (!match) {
 		throw new Error(`找不到 HTML element id: ${id}`);
 	}

--- a/src/test/suite/editorThemeSurfaceContractUtils.ts
+++ b/src/test/suite/editorThemeSurfaceContractUtils.ts
@@ -75,6 +75,35 @@ export function collectCssRuleBlocks(source: string, selectorPatterns: RegExp[])
 	return selectorPatterns.flatMap(pattern => getCssRuleBlocks(source, pattern)).join('\n');
 }
 
+export function extractBalancedCssBlock(source: string, startPattern: RegExp, context: string): string {
+	const css = stripCssComments(source);
+	startPattern.lastIndex = 0;
+	const match = startPattern.exec(css);
+	if (!match) {
+		throw new Error(`${context} 找不到 CSS block 起始 pattern: ${startPattern}`);
+	}
+
+	const openBraceIndex = css.indexOf('{', match.index);
+	if (openBraceIndex < 0) {
+		throw new Error(`${context} 找不到 CSS block 起始大括號`);
+	}
+
+	let depth = 0;
+	for (let index = openBraceIndex; index < css.length; index++) {
+		const character = css[index];
+		if (character === '{') {
+			depth++;
+		} else if (character === '}') {
+			depth--;
+			if (depth === 0) {
+				return css.slice(match.index, index + 1);
+			}
+		}
+	}
+
+	throw new Error(`${context} 找不到 CSS block 結束大括號`);
+}
+
 export function assertNoPatterns(source: string, forbiddenPatterns: RegExp[], context: string): void {
 	for (const pattern of forbiddenPatterns) {
 		pattern.lastIndex = 0;

--- a/src/test/suite/editorThemeSurfaceContractUtils.ts
+++ b/src/test/suite/editorThemeSurfaceContractUtils.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const REPOSITORY_ROOT = findRepositoryRoot(__dirname);
+
+export const HOST_TOKEN_ALLOWLIST_PATTERNS: RegExp[] = [
+	/^--vscode-focusBorder$/,
+	/^--vscode-contrast(?:Active)?Border$/,
+	/^--vscode-font-family$/,
+	/^--vscode-editor-font-family$/,
+	/^--vscode-editor-font-weight$/,
+	/^--vscode-editor-font-size$/,
+];
+
+export const HIGH_CONTRAST_SELECTOR_PATTERN = /body\.vscode-high-contrast(?:-light)?|forced-colors:\s*active/i;
+
+export const HOST_THEMED_STANDALONE_FILES = new Set(['media/css/platformioDiagnostic.css']);
+
+export const EDITOR_SURFACE_FORBIDDEN_HOST_BASE_TOKENS: RegExp[] = [
+	/var\(--vscode-(?:editor|sideBar|panel|input|list|badge)-[^)]+\)/i,
+	/var\(--vscode-inputValidation-(?:warning|error)(?:Background|Foreground|Border)[^)]*\)/i,
+];
+
+export function readWorkspaceFile(relativePath: string): string {
+	return fs.readFileSync(path.join(REPOSITORY_ROOT, relativePath), 'utf8');
+}
+
+export function stripCssComments(source: string): string {
+	return source.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+export function stripHtmlComments(source: string): string {
+	return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+export function normalizeWhitespace(source: string): string {
+	return source.replace(/\s+/g, ' ').trim();
+}
+
+export function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function getHtmlElementTag(source: string, id: string): string {
+	const pattern = new RegExp(`<[^>]+\\bid=["']${escapeRegExp(id)}["'][^>]*>`, 'i');
+	const match = stripHtmlComments(source).match(pattern);
+	if (!match) {
+		throw new Error(`找不到 HTML element id: ${id}`);
+	}
+	return match[0];
+}
+
+export function getCssRuleBlocks(source: string, selectorPattern: RegExp): string[] {
+	const css = stripCssComments(source);
+	const blocks: string[] = [];
+	const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+	let match: RegExpExecArray | null;
+	while ((match = rulePattern.exec(css)) !== null) {
+		const selector = match[1].trim();
+		if (selectorPattern.test(selector)) {
+			blocks.push(`${selector} {${match[2]}}`);
+		}
+		selectorPattern.lastIndex = 0;
+	}
+	return blocks;
+}
+
+export function collectCssRuleBlocks(source: string, selectorPatterns: RegExp[]): string {
+	return selectorPatterns.flatMap(pattern => getCssRuleBlocks(source, pattern)).join('\n');
+}
+
+export function assertNoPatterns(source: string, forbiddenPatterns: RegExp[], context: string): void {
+	for (const pattern of forbiddenPatterns) {
+		pattern.lastIndex = 0;
+		if (pattern.test(source)) {
+			throw new Error(`${context} 含有禁止 pattern: ${pattern}`);
+		}
+	}
+}
+
+export function extractSourceBetween(source: string, startMarker: string, endMarker: string, context: string): string {
+	const start = source.indexOf(startMarker);
+	if (start < 0) {
+		throw new Error(`${context} 找不到起始 marker: ${startMarker}`);
+	}
+
+	const end = source.indexOf(endMarker, start + startMarker.length);
+	if (end <= start) {
+		throw new Error(`${context} 找不到結束 marker: ${endMarker}`);
+	}
+
+	return source.slice(start, end);
+}
+
+export function assertNoWebViewReloadAntipatterns(source: string, context: string): void {
+	assertNoPatterns(source, [/webview\.html|location\.reload|window\.location/], context);
+}
+
+export function extractVscodeTokens(source: string): string[] {
+	const tokens = new Set<string>();
+	const tokenPattern = /--vscode-[a-zA-Z0-9-]+/g;
+	let match: RegExpExecArray | null;
+	while ((match = tokenPattern.exec(source)) !== null) {
+		tokens.add(match[0]);
+	}
+	return [...tokens].sort();
+}
+
+export function isAllowedHostToken(token: string, sourceContext: string, filePath?: string): boolean {
+	if (filePath && HOST_THEMED_STANDALONE_FILES.has(filePath)) {
+		return true;
+	}
+
+	if (HOST_TOKEN_ALLOWLIST_PATTERNS.some(pattern => pattern.test(token))) {
+		return true;
+	}
+
+	if (HIGH_CONTRAST_SELECTOR_PATTERN.test(sourceContext)) {
+		return true;
+	}
+
+	return false;
+}
+
+export function findDisallowedHostTokens(source: string, options?: { filePath?: string; sourceContext?: string }): string[] {
+	const sourceContext = options?.sourceContext ?? source;
+	return extractVscodeTokens(source).filter(token => !isAllowedHostToken(token, sourceContext, options?.filePath));
+}
+
+export function assertOnlyAllowedHostTokens(source: string, context: string, options?: { filePath?: string; sourceContext?: string }): void {
+	const disallowedTokens = findDisallowedHostTokens(source, options);
+	if (disallowedTokens.length > 0) {
+		throw new Error(`${context} 含有未列入 allowlist 的 host theme token: ${disallowedTokens.join(', ')}`);
+	}
+}
+
+function findRepositoryRoot(startDirectory: string): string {
+	let current = startDirectory;
+	while (true) {
+		if (fs.existsSync(path.join(current, 'package.json')) && fs.existsSync(path.join(current, 'media'))) {
+			return current;
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) {
+			throw new Error(`無法從 ${startDirectory} 找到 repository root`);
+		}
+		current = parent;
+	}
+}

--- a/src/test/suite/editorThemeSurfaceSampleBrowserContract.test.ts
+++ b/src/test/suite/editorThemeSurfaceSampleBrowserContract.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import {
+	assertNoPatterns,
+	collectCssRuleBlocks,
+	EDITOR_SURFACE_FORBIDDEN_HOST_BASE_TOKENS,
+	readWorkspaceFile,
+} from './editorThemeSurfaceContractUtils';
+
+const SAMPLE_BROWSER_SELECTOR_PATTERNS = [
+	/\.sample-modal-content/,
+	/\.sample-offline-notice/,
+	/\.sample-spinner/,
+	/\.sample-category-header/,
+	/\.sample-card(?:\b|:)/,
+	/\.sample-card-description/,
+	/\.sample-card-load-btn/,
+	/\.sample-empty-notice/,
+];
+
+describe('Editor theme surface contract: Sample Browser', () => {
+	it('keeps card, category, notice, loading and empty-state selectors off host base tokens', () => {
+		const css = readWorkspaceFile('media/css/blocklyEdit.css');
+		const sampleBrowserRules = collectCssRuleBlocks(css, SAMPLE_BROWSER_SELECTOR_PATTERNS);
+
+		assert(sampleBrowserRules.includes('.sample-card'), 'Sample Browser card selector should be covered by this contract');
+		assert(sampleBrowserRules.includes('.sample-offline-notice'), 'Sample Browser offline notice selector should be covered by this contract');
+		assertNoPatterns(
+			sampleBrowserRules,
+			EDITOR_SURFACE_FORBIDDEN_HOST_BASE_TOKENS,
+			'Sample Browser editor-owned selectors'
+		);
+	});
+});

--- a/src/test/suite/editorThemeSurfaceTxtModalContract.test.ts
+++ b/src/test/suite/editorThemeSurfaceTxtModalContract.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'mocha';
+import {
+	assertNoPatterns,
+	getHtmlElementTag,
+	readWorkspaceFile,
+} from './editorThemeSurfaceContractUtils';
+
+const TXT_CONNECTION_INPUT_IDS = [
+	'txtHostInput',
+	'txtUsernameInput',
+	'txtPasswordInput',
+	'txtRemotePathInput',
+];
+
+const INLINE_HOST_INPUT_PATTERNS = [
+	/style=["'][^"']*--vscode-input-background/i,
+	/style=["'][^"']*--vscode-input-foreground/i,
+	/style=["'][^"']*--vscode-input-border/i,
+];
+
+describe('Editor theme surface contract: TXT connection modal', () => {
+	it('does not use inline VS Code input theme tokens on connection fields', () => {
+		const html = readWorkspaceFile('media/html/blocklyEdit.html');
+
+		for (const inputId of TXT_CONNECTION_INPUT_IDS) {
+			const inputTag = getHtmlElementTag(html, inputId);
+			assertNoPatterns(inputTag, INLINE_HOST_INPUT_PATTERNS, `#${inputId}`);
+		}
+	});
+});

--- a/src/test/suite/editorThemeSurfaceTxtVirtualControlsContract.test.ts
+++ b/src/test/suite/editorThemeSurfaceTxtVirtualControlsContract.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import {
+	assertNoPatterns,
+	collectCssRuleBlocks,
+	getCssRuleBlocks,
+	readWorkspaceFile,
+} from './editorThemeSurfaceContractUtils';
+
+const TXT_VIRTUAL_CONTROL_TOKEN_ASSIGNMENT = /--txt-virtual-controls-[\w-]+\s*:/i;
+
+describe('Editor theme surface contract: TXT virtual controls', () => {
+	it('does not assign TXT virtual controls base tokens from host vscode light/dark selectors', () => {
+		const css = readWorkspaceFile('media/css/blocklyEdit.css');
+		const hostThemeBlocks = collectCssRuleBlocks(css, [/body\.vscode-light/, /body\.vscode-dark/]);
+
+		assertNoPatterns(
+			hostThemeBlocks,
+			[TXT_VIRTUAL_CONTROL_TOKEN_ASSIGNMENT],
+			'TXT virtual controls light/dark token ownership'
+		);
+	});
+
+	it('uses editor-owned scrollbar tokens for TXT virtual controls in backup preview canvas', () => {
+		const css = readWorkspaceFile('media/css/blocklyEdit.css');
+		const previewCanvasBlocks = getCssRuleBlocks(css, /body\.preview-mode\s+\.txt-preview-canvas(?:\b|:|::)/).join('\n');
+
+		assert.match(
+			previewCanvasBlocks,
+			/scrollbar-color\s*:\s*var\(--editor-scrollbar-thumb\)\s+var\(--editor-scrollbar-track\)/,
+			'Firefox scrollbar colors must follow the editor theme, not the VS Code host theme'
+		);
+		assert.match(
+			previewCanvasBlocks,
+			/::-webkit-scrollbar-track[\s\S]*background(?:-color)?\s*:\s*var\(--editor-scrollbar-track\)/,
+			'WebKit scrollbar track must follow the editor theme'
+		);
+		assert.match(
+			previewCanvasBlocks,
+			/::-webkit-scrollbar-thumb[\s\S]*background(?:-color)?\s*:\s*var\(--editor-scrollbar-thumb\)/,
+			'WebKit scrollbar thumb must follow the editor theme'
+		);
+		assert.match(
+			previewCanvasBlocks,
+			/::-webkit-scrollbar-thumb:hover[\s\S]*background(?:-color)?\s*:\s*var\(--editor-scrollbar-thumb-hover\)/,
+			'WebKit scrollbar hover thumb must follow the editor theme'
+		);
+	});
+});

--- a/src/test/suite/editorThemeSwitchContract.test.ts
+++ b/src/test/suite/editorThemeSwitchContract.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import {
+	assertNoWebViewReloadAntipatterns,
+	extractSourceBetween,
+	readWorkspaceFile,
+} from './editorThemeSurfaceContractUtils';
+
+describe('Editor theme runtime switch contract', () => {
+	it('updates body theme classes and Blockly theme without WebView reload assumptions', () => {
+		const source = readWorkspaceFile('media/js/blocklyEdit.js');
+		const updateThemeBody = extractSourceBetween(
+			source,
+			'function updateTheme(theme)',
+			'// 監聽語言變更事件',
+			'blocklyEdit.js updateTheme(theme) contract slice'
+		);
+
+		assert(updateThemeBody.includes("document.body.classList.remove('theme-light', 'theme-dark')"));
+		assert(updateThemeBody.includes('document.body.classList.add(`theme-${theme}`)'));
+		assert(updateThemeBody.includes('Blockly.getMainWorkspace().setTheme(window.SingularBlocklyDarkTheme)'));
+		assert(updateThemeBody.includes('Blockly.getMainWorkspace().setTheme(window.SingularBlocklyTheme)'));
+		assert(updateThemeBody.includes('refreshTxtVirtualControlsUI()'));
+		assertNoWebViewReloadAntipatterns(updateThemeBody, 'blocklyEdit.js updateTheme(theme)');
+	});
+
+	it('persists toolbar theme toggles through postMessage without rebuilding the WebView', () => {
+		const source = readWorkspaceFile('media/js/blocklyEdit.js');
+		const toggleThemeBody = extractSourceBetween(
+			source,
+			'function toggleTheme()',
+			'// 重新整理程式碼處理函數',
+			'blocklyEdit.js toggleTheme() contract slice'
+		);
+
+		assert(toggleThemeBody.includes('updateTheme(currentTheme)'));
+		assert(toggleThemeBody.includes("command: 'updateTheme'"));
+		assertNoWebViewReloadAntipatterns(toggleThemeBody, 'blocklyEdit.js toggleTheme()');
+	});
+});

--- a/src/test/suite/editorThemeTouchedFeedbackContract.test.ts
+++ b/src/test/suite/editorThemeTouchedFeedbackContract.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import {
+	assertNoPatterns,
+	collectCssRuleBlocks,
+	getCssRuleBlocks,
+	readWorkspaceFile,
+} from './editorThemeSurfaceContractUtils';
+
+const LOW_CONTRAST_LITERAL_PATTERNS = [
+	/(?:color|background(?:-color)?|border(?:-color)?)\s*:\s*#888\b/i,
+	/(?:color|background(?:-color)?|border(?:-color)?)\s*:\s*#888888\b/i,
+];
+
+const TOUCHED_FEEDBACK_SELECTOR_PATTERNS = [
+	/\.txt-connection-status\b/,
+	/\.txt-connection-hint\b/,
+	/\.sample-offline-notice\b/,
+	/\.sample-spinner\b/,
+	/\.sample-empty-notice\b/,
+	/\.txt-virtual-controls-canvas-hint\b/,
+	/\.txt-virtual-controls-empty-state\b/,
+	/\.txt-virtual-controls-inspector-empty\b/,
+	/\.txt-preview-warning-item\b/,
+	/#txtVirtualControlsToggle\.has-invalid-references\b/,
+];
+
+describe('Editor theme touched feedback contract', () => {
+	it('keeps touched feedback readable through editor-owned tokens instead of fixed low-contrast colors', () => {
+		const css = readWorkspaceFile('media/css/blocklyEdit.css');
+		const touchedFeedbackBlocks = collectCssRuleBlocks(css, TOUCHED_FEEDBACK_SELECTOR_PATTERNS);
+
+		assertNoPatterns(touchedFeedbackBlocks, LOW_CONTRAST_LITERAL_PATTERNS, 'touched feedback styles');
+
+		const txtConnectionStatusBlocks = getCssRuleBlocks(css, /\.txt-connection-status\b/).join('\n');
+		assert.match(
+			txtConnectionStatusBlocks,
+			/color\s*:\s*var\(--editor-description-fg\)/,
+			'TXT connection base status must keep a readable editor-owned description color before success/error classes apply'
+		);
+	});
+});

--- a/src/test/suite/editorThemeTouchedFeedbackI18nContract.test.ts
+++ b/src/test/suite/editorThemeTouchedFeedbackI18nContract.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import { getHtmlElementTag, readWorkspaceFile } from './editorThemeSurfaceContractUtils';
+
+describe('Editor theme touched feedback i18n contract', () => {
+	it('keeps touched feedback text locale-backed while preserving base feedback roles/classes', () => {
+		const html = readWorkspaceFile('media/html/blocklyEdit.html');
+		const source = readWorkspaceFile('media/js/blocklyEdit.js');
+
+		assert.match(getHtmlElementTag(html, 'txtConnectionStatus'), /class=["']txt-connection-status["']/);
+		assert.match(source, /getMessage\(\s*'TXT_TESTING'/);
+		assert.match(source, /getMessage\(\s*'TXT_SSH_CONFIRM_HINT'/);
+		assert.match(source, /getMessage\(\s*'TXT_SSH_SETUP_DONE'/);
+		assert.match(source, /getMessage\(\s*'SAMPLE_BROWSER_OFFLINE_NOTICE'/);
+		assert.match(source, /getMessage\(\s*'SAMPLE_BROWSER_EMPTY'/);
+
+		assert(!/sshHint\.style\.color\s*=\s*['"]var\(--vscode-/.test(source), 'TXT SSH hint must not use inline host-token color overrides');
+		assert(!/statusEl\.className\s*=\s*''/.test(source), 'TXT connection status must not drop the base feedback class while showing progress text');
+		assert(!/statusEl\.className\s*=\s*message\.success\s*\?/.test(source), 'TXT connection status must preserve the base feedback class when applying success/error roles');
+	});
+});

--- a/src/test/suite/editorThemeTxtVirtualControlsSwitchContract.test.ts
+++ b/src/test/suite/editorThemeTxtVirtualControlsSwitchContract.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert = require('assert');
+import { describe, it } from 'mocha';
+import * as path from 'path';
+import {
+	assertNoWebViewReloadAntipatterns,
+	extractSourceBetween,
+	REPOSITORY_ROOT,
+	readWorkspaceFile,
+} from './editorThemeSurfaceContractUtils';
+
+interface ClassListLike {
+	contains(className: string): boolean;
+}
+
+interface TxtVirtualControlsContrastApi {
+	getThemeMode(body?: { classList?: ClassListLike }): 'light' | 'dark' | 'high-contrast';
+}
+
+describe('Editor theme TXT virtual controls switch contract', () => {
+	it('refreshes TXT virtual controls during runtime theme switches without reload assumptions', () => {
+		const source = readWorkspaceFile('media/js/blocklyEdit.js');
+		const updateThemeBody = extractSourceBetween(
+			source,
+			'function updateTheme(theme)',
+			'// 監聽語言變更事件',
+			'blocklyEdit.js updateTheme(theme) contract slice'
+		);
+
+		assert(updateThemeBody.includes('refreshTxtVirtualControlsUI()'));
+		assertNoWebViewReloadAntipatterns(updateThemeBody, 'blocklyEdit.js TXT virtual controls updateTheme(theme)');
+	});
+
+	it('prefers editor theme classes over host theme classes for TXT virtual controls fallback mode', () => {
+		const helperPath = path.join(REPOSITORY_ROOT, 'media/js/txtVirtualControlsContrast.js');
+		delete require.cache[require.resolve(helperPath)];
+		const contrast = require(helperPath) as TxtVirtualControlsContrastApi;
+		const mixedThemeBody = {
+			classList: {
+				contains: (className: string) => className === 'theme-light' || className === 'vscode-dark',
+			},
+		};
+
+		assert.strictEqual(contrast.getThemeMode(mixedThemeBody), 'light');
+	});
+});

--- a/src/test/webviewManager.test.ts
+++ b/src/test/webviewManager.test.ts
@@ -268,6 +268,32 @@ describe('WebView Manager', () => {
 		);
 	});
 
+	(skipInCoverage ? it.skip : it)('should inject stored editor theme into initial theme and body class', async () => {
+		vscodeMock.workspace.workspaceFolders = [{ uri: { fsPath: '/mock/workspace' } }];
+		fsMock.addFile('/mock/workspace/.vscode/settings.json', JSON.stringify({ 'singular-blockly.theme': 'dark' }));
+
+		const webviewMock = {
+			html: '',
+			onDidReceiveMessage: sinon.stub(),
+			postMessage: sinon.stub().resolves(),
+			asWebviewUri: sinon.stub().callsFake((uri: any) => {
+				return `https://mock-webview/${uri.fsPath.replace(/\\/g, '/')}`;
+			}),
+		};
+
+		vscodeMock.window.createWebviewPanel = sinon.stub().returns({
+			webview: webviewMock,
+			onDidDispose: sinon.stub(),
+			reveal: sinon.stub(),
+		});
+
+		await webViewManager.createAndShowWebView();
+
+		assert(webviewMock.html.includes("window.initialTheme = 'dark'"));
+		assert(webviewMock.html.includes('class="theme-dark"'));
+		assert(!webviewMock.html.includes('class="theme-light"'));
+	});
+
 	it('should handle panel disposal', async () => {
 		// 設定 VS Code 工作區
 		vscodeMock.workspace.workspaceFolders = [{ uri: { fsPath: '/mock/workspace' } }];


### PR DESCRIPTION
## 變更摘要 Summary

修正 Blockly 編輯器內 editor-owned surfaces 在 VS Code host 深色/淺色主題交錯時的主題滲漏問題，讓 TXT connection modal、Sample Browser、TXT virtual controls 與備份預覽 chrome 都跟隨 Blockly editor theme，而不是 VS Code host theme。

## 相關 Spec Related Spec

- Spec: `specs/057-editor-theme-surface-consistency/spec.md`
- Tasks: `specs/057-editor-theme-surface-consistency/tasks.md`
- Validation: `specs/057-editor-theme-surface-consistency/manual-validation.md`

## 變更類型 Type of Change

- [x] 🐛 Bug 修復 (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 (non-breaking change which adds functionality)
- [ ] 💥 破壞性變更 (fix or feature that would cause existing functionality to change)
- [x] 📝 文件更新 (documentation only changes)

## 變更內容 Changes

- 將 editor surfaces 的 light/dark ownership 收斂到 `body.theme-light` / `body.theme-dark` 與 editor-owned CSS tokens。
- 移除 TXT connection modal、Sample Browser、TXT virtual controls 與備份預覽中不該跟隨 host theme 的 `--vscode-*` / fixed color leakage。
- 補強 runtime `updateTheme(theme)` contract，確認主題切換不 reload WebView 且可刷新 TXT virtual controls。
- 補上備份預覽 full audit：preview chrome、board warning、theme toggle focus ring、TXT preview scrollbar 與 forced-colors coverage。
- 新增 source-contract tests 與手動驗證紀錄，鎖定未來 regression。

## 測試計劃 Test Plan

- [x] `npm run compile` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過：765 passing, 1 pending
- [x] `npm run validate:i18n` 通過：14/14 languages, 0 errors（保留既有 length warnings）
- [x] Source-contract theme tests 通過：18 passing
- [x] Backup preview target test 通過：13 passing
- [x] 手動測試完成：VS Code host / Blockly editor 主題交錯與備份預覽檢查

## 備註 Notes

- `media/css/platformioDiagnostic.css` 維持 standalone host-themed exception。
- `media/css/shadowBlock.css` 本輪未觸及，依 spec 記錄為 secondary overlay out-of-scope。
