### PR TITLE
fix(i18n): remove duplicate X11 LED R label

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/media/blockly/blocks/x11.js
+++ b/media/blockly/blocks/x11.js
@@ -165,6 +165,7 @@ Blockly.Blocks['x11_led_digital'] = {
 			.appendField(window.languageManager.getMessage('X11_LED_SET_COLOR_INDEX', '第'))
 			.appendField(new Blockly.FieldDropdown(getX11LedIndexOptions), 'INDEX')
 			.appendField(window.languageManager.getMessage('X11_LED_SET_COLOR_INDEX_SUFFIX', '顆'))
+			.appendField('R')
 			.appendField(new Blockly.FieldDropdown(getDigitalStateOptions), 'R_STATE')
 			.appendField('G')
 			.appendField(new Blockly.FieldDropdown(getDigitalStateOptions), 'G_STATE')

--- a/media/locales/bg/messages.js
+++ b/media/locales/bg/messages.js
@@ -1091,7 +1091,7 @@ window.languageManager.loadMessages('bg', {
 	// X11 LED блокове
 	X11_LED_SET_COLOR_PREFIX: 'LED лента',
 	X11_LED_SET_COLOR_INDEX: 'индекс',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'задай цвят R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'пиксел',
 	X11_LED_SET_COLOR_TOOLTIP: 'Задай цвят на пиксел на LED лента (индекс 0=първи пиксел, или всички)',
 	X11_LED_DIGITAL_TOOLTIP: 'Задай каналните състояния на LED лентата X11 на ВКЛ или ИЗКЛ',
 	X11_LED_INDEX_ALL: 'Всички',

--- a/media/locales/cs/messages.js
+++ b/media/locales/cs/messages.js
@@ -1087,7 +1087,7 @@ window.languageManager.loadMessages('cs', {
 	// X11 LED bloky
 	X11_LED_SET_COLOR_PREFIX: 'LED pásek',
 	X11_LED_SET_COLOR_INDEX: 'index',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'nastav barvu R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'pixel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Nastav barvu pixelu LED pásku (index 0=první pixel, nebo všechny)',
 	X11_LED_DIGITAL_TOOLTIP: 'Nastavit stavy kanálů LED pásku X11 na ZAP nebo VYP',
 	X11_LED_INDEX_ALL: 'Všechny',

--- a/media/locales/de/messages.js
+++ b/media/locales/de/messages.js
@@ -1090,7 +1090,7 @@ window.languageManager.loadMessages('de', {
 	// X11 LED Blöcke
 	X11_LED_SET_COLOR_PREFIX: 'LED-Streifen',
 	X11_LED_SET_COLOR_INDEX: 'Index',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'setze Farbe R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'Pixel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Setze LED-Streifen Pixel-Farbe (Index 0=erstes Pixel, oder alle)',
 	X11_LED_DIGITAL_TOOLTIP: 'X11-LED-Streifen-Kanalzustände Ein oder Aus schalten',
 	X11_LED_INDEX_ALL: 'Alle',

--- a/media/locales/en/messages.js
+++ b/media/locales/en/messages.js
@@ -1094,7 +1094,7 @@ window.languageManager.loadMessages('en', {
 	// X11 LED Blocks
 	X11_LED_SET_COLOR_PREFIX: 'LED strip',
 	X11_LED_SET_COLOR_INDEX: 'index',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'set color R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'pixel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Set LED strip pixel color (index 0=first pixel, or all)',
 	X11_LED_DIGITAL_TOOLTIP: 'Set X11 LED strip channel states ON or OFF',
 	X11_LED_INDEX_ALL: 'All',

--- a/media/locales/es/messages.js
+++ b/media/locales/es/messages.js
@@ -1088,7 +1088,7 @@ window.languageManager.loadMessages('es', {
 	// Bloques de LED X11
 	X11_LED_SET_COLOR_PREFIX: 'Tira LED',
 	X11_LED_SET_COLOR_INDEX: 'índice',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'establecer color R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'píxel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Establecer color de píxel de tira LED (índice 0=primer píxel, o todos)',
 	X11_LED_DIGITAL_TOOLTIP: 'Establecer los estados de los canales de la tira LED X11 en ON u OFF',
 	X11_LED_INDEX_ALL: 'Todos',

--- a/media/locales/fr/messages.js
+++ b/media/locales/fr/messages.js
@@ -1088,7 +1088,7 @@ window.languageManager.loadMessages('fr', {
 	// Blocs LED X11
 	X11_LED_SET_COLOR_PREFIX: 'Bande LED',
 	X11_LED_SET_COLOR_INDEX: 'index',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'définir couleur R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'pixel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Définir la couleur du pixel de la bande LED (index 0=premier pixel, ou tous)',
 	X11_LED_DIGITAL_TOOLTIP: 'Activer ou désactiver les canaux de la bande LED X11',
 	X11_LED_INDEX_ALL: 'Tous',

--- a/media/locales/hu/messages.js
+++ b/media/locales/hu/messages.js
@@ -1092,7 +1092,7 @@ window.languageManager.loadMessages('hu', {
 	// X11 LED blokkok
 	X11_LED_SET_COLOR_PREFIX: 'LED szalag',
 	X11_LED_SET_COLOR_INDEX: 'index',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'állítsd színre R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'pixel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Állítsd be a LED szalag pixel színét (index 0=első pixel, vagy mind)',
 	X11_LED_DIGITAL_TOOLTIP: 'X11 LED szalag csatorna állapotainak beállítása BE/KI',
 	X11_LED_INDEX_ALL: 'Mind',

--- a/media/locales/it/messages.js
+++ b/media/locales/it/messages.js
@@ -1086,7 +1086,7 @@ window.languageManager.loadMessages('it', {
 	// Blocchi LED X11
 	X11_LED_SET_COLOR_PREFIX: 'Striscia LED',
 	X11_LED_SET_COLOR_INDEX: 'indice',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'imposta colore R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'pixel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Imposta il colore del pixel della striscia LED (indice 0=primo pixel, o tutti)',
 	X11_LED_DIGITAL_TOOLTIP: 'Imposta gli stati dei canali della striscia LED X11 su ON o OFF',
 	X11_LED_INDEX_ALL: 'Tutti',

--- a/media/locales/ja/messages.js
+++ b/media/locales/ja/messages.js
@@ -1082,7 +1082,7 @@ window.languageManager.loadMessages('ja', {
 	// X11 LED ブロック
 	X11_LED_SET_COLOR_PREFIX: 'LEDテープ',
 	X11_LED_SET_COLOR_INDEX: 'インデックス',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'の色を設定 R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: '番目',
 	X11_LED_SET_COLOR_TOOLTIP: 'LEDテープのピクセル色を設定 (インデックス 0=最初、または全て)',
 	X11_LED_DIGITAL_TOOLTIP: 'X11 LEDテープのチャンネル状態をON/OFFに設定する',
 	X11_LED_INDEX_ALL: '全て',

--- a/media/locales/ko/messages.js
+++ b/media/locales/ko/messages.js
@@ -1082,7 +1082,7 @@ window.languageManager.loadMessages('ko', {
 	// X11 LED 블록
 	X11_LED_SET_COLOR_PREFIX: 'LED 스트립',
 	X11_LED_SET_COLOR_INDEX: '인덱스',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: '색상 설정 R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: '픽셀',
 	X11_LED_SET_COLOR_TOOLTIP: 'LED 스트립 픽셀 색상 설정 (인덱스 0=첫 번째, 또는 전체)',
 	X11_LED_DIGITAL_TOOLTIP: 'X11 LED 스트립 채널 상태를 ON 또는 OFF로 설정',
 	X11_LED_INDEX_ALL: '전체',

--- a/media/locales/pl/messages.js
+++ b/media/locales/pl/messages.js
@@ -1090,7 +1090,7 @@ window.languageManager.loadMessages('pl', {
 	// X11 LED bloki
 	X11_LED_SET_COLOR_PREFIX: 'Taśma LED',
 	X11_LED_SET_COLOR_INDEX: 'indeks',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'ustaw kolor R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'piksel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Ustaw kolor piksela taśmy LED (indeks 0=pierwszy piksel, lub wszystkie)',
 	X11_LED_DIGITAL_TOOLTIP: 'Ustaw stany kanałów taśmy LED X11 na WŁ lub WYŁ',
 	X11_LED_INDEX_ALL: 'Wszystkie',

--- a/media/locales/pt-br/messages.js
+++ b/media/locales/pt-br/messages.js
@@ -1083,7 +1083,7 @@ window.languageManager.loadMessages('pt-br', {
 	// Blocos de LED X11
 	X11_LED_SET_COLOR_PREFIX: 'Fita LED',
 	X11_LED_SET_COLOR_INDEX: 'índice',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'definir cor R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'pixel',
 	X11_LED_SET_COLOR_TOOLTIP: 'Definir cor do pixel da fita LED (índice 0=primeiro pixel, ou todos)',
 	X11_LED_DIGITAL_TOOLTIP: 'Definir estados dos canais da fita LED X11 como LIGADO ou DESLIGADO',
 	X11_LED_INDEX_ALL: 'Todos',

--- a/media/locales/ru/messages.js
+++ b/media/locales/ru/messages.js
@@ -1086,7 +1086,7 @@ window.languageManager.loadMessages('ru', {
 	// X11 LED блоки
 	X11_LED_SET_COLOR_PREFIX: 'LED лента',
 	X11_LED_SET_COLOR_INDEX: 'индекс',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'установить цвет R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'пиксель',
 	X11_LED_SET_COLOR_TOOLTIP: 'Установить цвет пикселя LED ленты (индекс 0=первый пиксель, или все)',
 	X11_LED_DIGITAL_TOOLTIP: 'Установить состояния каналов LED ленты X11 ВКЛ или ВЫКЛ',
 	X11_LED_INDEX_ALL: 'Все',

--- a/media/locales/tr/messages.js
+++ b/media/locales/tr/messages.js
@@ -1090,7 +1090,7 @@ window.languageManager.loadMessages('tr', {
 	// X11 LED blokları
 	X11_LED_SET_COLOR_PREFIX: 'LED şerit',
 	X11_LED_SET_COLOR_INDEX: 'indeks',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: 'renk ayarla R',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: 'piksel',
 	X11_LED_SET_COLOR_TOOLTIP: 'LED şerit piksel rengini ayarla (indeks 0=ilk piksel veya tümü)',
 	X11_LED_DIGITAL_TOOLTIP: 'X11 LED şerit kanal durumlarını AÇIK veya KAPALI olarak ayarla',
 	X11_LED_INDEX_ALL: 'Tümü',

--- a/media/locales/zh-hant/messages.js
+++ b/media/locales/zh-hant/messages.js
@@ -1078,7 +1078,7 @@ window.languageManager.loadMessages('zh-hant', {
 	// X11 LED 燈條積木
 	X11_LED_SET_COLOR_PREFIX: 'LED 燈條',
 	X11_LED_SET_COLOR_INDEX: '第',
-	X11_LED_SET_COLOR_INDEX_SUFFIX: '顆設定顏色 紅',
+	X11_LED_SET_COLOR_INDEX_SUFFIX: '顆',
 	X11_LED_SET_COLOR_TOOLTIP: '設定 LED 燈條像素顏色 (索引 0=第一顆，或全部)',
 	X11_LED_DIGITAL_TOOLTIP: '設定 X11 LED 燈條各通道狀態為開或關',
 	X11_LED_INDEX_ALL: '全部',

--- a/specs/060-cyberbrick-led-digital/data-model.md
+++ b/specs/060-cyberbrick-led-digital/data-model.md
@@ -67,10 +67,10 @@
 ### Visual Layout (inline)
 
 ```
-[ LED strip [D1▾]  index [1▾]  set color R  R [ON▾]  G [ON▾]  B [ON▾] ]
+[ LED strip [D1▾]  index [1▾]  pixel  R [ON▾]  G [ON▾]  B [ON▾] ]
 ```
 
-> Note: "set color R" is the value of `X11_LED_SET_COLOR_INDEX_SUFFIX` in English locale.
+> Note: "pixel" is the English value of `X11_LED_SET_COLOR_INDEX_SUFFIX`; the channel label `R` is appended by the block itself.
 
 ### Hardware Mapping
 

--- a/src/test/suite/x11LedI18n.test.ts
+++ b/src/test/suite/x11LedI18n.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Singular Blockly Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const EXPECTED_INDEX_SUFFIXES: Record<string, string> = {
+	bg: 'пиксел',
+	cs: 'pixel',
+	de: 'Pixel',
+	en: 'pixel',
+	es: 'píxel',
+	fr: 'pixel',
+	hu: 'pixel',
+	it: 'pixel',
+	ja: '番目',
+	ko: '픽셀',
+	pl: 'piksel',
+	'pt-br': 'pixel',
+	ru: 'пиксель',
+	tr: 'piksel',
+	'zh-hant': '顆',
+};
+
+function extractMessageValue(source: string, key: string): string | null {
+	const doubleQuoted = new RegExp(`${key}:\\s*"((?:[^"\\\\]|\\\\.)*)"`);
+	let match = source.match(doubleQuoted);
+	if (match) {
+		return match[1].replace(/\\'/g, "'").replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+	}
+
+	const singleQuoted = new RegExp(`${key}:\\s*'((?:[^'\\\\]|\\\\.)*)'`);
+	match = source.match(singleQuoted);
+	if (match) {
+		return match[1].replace(/\\'/g, "'").replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+	}
+
+	return null;
+}
+
+suite('X11 LED i18n Tests', () => {
+	const localesRoot = path.join(__dirname, '..', '..', '..', 'media', 'locales');
+	const locales = fs
+		.readdirSync(localesRoot, { withFileTypes: true })
+		.filter(entry => entry.isDirectory())
+		.map(entry => entry.name)
+		.sort();
+
+	test('所有 locale 應使用核准的 X11 LED index suffix', () => {
+		assert.strictEqual(locales.length, 15, 'project should keep 15 supported locales');
+		assert.deepStrictEqual(locales, Object.keys(EXPECTED_INDEX_SUFFIXES).sort(), 'supported locales should match the approved suffix map');
+
+		for (const locale of locales) {
+			const source = fs.readFileSync(path.join(localesRoot, locale, 'messages.js'), 'utf8');
+			const value = extractMessageValue(source, 'X11_LED_SET_COLOR_INDEX_SUFFIX');
+
+			assert.strictEqual(value, EXPECTED_INDEX_SUFFIXES[locale], `${locale} should use the approved X11 LED index suffix`);
+			assert.doesNotMatch(value ?? '', /(^|[^A-Za-z])R([^A-Za-z]|$)/, `${locale} suffix should not include an R channel label`);
+			assert.ok(!value?.includes('紅'), `${locale} suffix should not include a red channel label`);
+		}
+	});
+});


### PR DESCRIPTION
## 變更摘要 Summary

修正 X11 LED 顏色與數位控制積木在 15 個語系中出現重複 R 標籤的 UI 問題。`X11_LED_SET_COLOR_INDEX_SUFFIX` 現在只保留燈珠單位/序位，`x11_led_digital` 另外明確顯示自己的 R 通道標籤。

## 變更類型 Type of Change

- [x] 🐛 Bug 修復 (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 (non-breaking change which adds functionality)
- [ ] 💥 破壞性變更 (fix or feature that would cause existing functionality to change)
- [x] 📝 文件更新 (documentation only changes)

## 變更內容 Changes

- 更新 15 個 locale 的 `X11_LED_SET_COLOR_INDEX_SUFFIX`，移除色彩動作文字與 R/紅通道標籤。
- 在 `x11_led_digital` 的 `R_STATE` dropdown 前新增固定 `R` label。
- 新增 X11 LED i18n contract test，鎖定 locale suffix 核准值並防止 R/紅回歸。
- 更新 CyberBrick LED digital spec data model 的 UI 說明。

## 測試 Tests

- [x] `npm run compile-tests`
- [x] `npm run lint`
- [x] `npm run validate:i18n` (0 errors; existing warnings only)
- [x] `npm test` (888 passing, 1 pending)

## 發布建議 Release Note

建議合併後以 patch release 發布，例如 `0.82.6`。
