### PR TITLE
fix(micropython): restore Windows CyberBrick upload path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.82.9] - 2026-06-04
+
+### 🐛 修復 Bug Fixes
+
+- **CyberBrick Windows pyserial helper 路徑修復** (CyberBrick Windows pyserial helper path fix)
+    - Python / pyserial 暫存 helper 改用 `execFile` argv 直接執行，不再套用 Windows short path；修正 short path 可能產生 `C:\"C:\...\"` 無效路徑，導致 Windows 上中斷裝置失敗、USB 上傳失敗與 Wi-Fi 掃描失敗的問題
+      Python / pyserial temporary helpers now run directly through `execFile` argv without Windows short path conversion; fixes malformed `C:\"C:\...\"` paths that caused device interrupt, USB upload, and Wi-Fi scan failures on Windows
+    - Windows short path helper 移除 `cmd /s` 並驗證輸出格式；若輸出含 quote 或格式異常，會回退使用原始路徑
+      Windows short path helper no longer uses `cmd /s` and now validates output; malformed paths containing quotes fall back to the original path
+
+## [0.82.8] - 2026-06-04
+
+### 🐛 修復 Bug Fixes
+
+- **CyberBrick Windows mpremote 命令相容性修復** (CyberBrick Windows mpremote command compatibility fix)
+    - Windows 上 `mpremote` helper 命令恢復為接近 v0.82.5 的格式：只 quote executable、COM port 與本機檔案路徑，`connect` / `resume` / `+` / `run` / `fs cp` 等 mpremote token 不再加引號；修正 v0.82.7 在 Windows 造成 Wi-Fi 掃描與 USB 上傳失敗的回歸
+      Windows `mpremote` helper commands now use a format close to v0.82.5: only the executable, COM port, and local file paths are quoted, while `connect` / `resume` / `+` / `run` / `fs cp` tokens remain unquoted; fixes the v0.82.7 regression that broke Wi-Fi scan and USB upload on Windows
+    - 保留 CodeQL Alert #11 的修復方向：不再使用 incomplete backslash quote，避免重新引入 `js/incomplete-sanitization`
+      Keeps the CodeQL Alert #11 fix: incomplete backslash quoting is not reintroduced, avoiding `js/incomplete-sanitization`
+
+## [0.82.7] - 2026-06-04
+
+### 🔒 安全性修復 Security Fixes
+
+- **修復 CyberBrick MicroPython 上傳命令參數跳脫風險** (Fix CyberBrick MicroPython upload command argument escaping risk)
+    - 將實際 `python` / `mpremote` 執行路徑改為 `execFile` + argv 陣列，避免依賴 shell 字串跳脫，修復 GitHub Code scanning Alert #11 (`js/incomplete-sanitization`)
+      Changed actual `python` / `mpremote` execution to `execFile` with argv arrays instead of relying on shell string escaping, fixing GitHub Code scanning Alert #11 (`js/incomplete-sanitization`)
+    - Windows fallback command 字串不再使用 backslash quote 形式，避免破壞含反斜線路徑；Windows short path helper 也改用 `execFileSync` + 環境變數傳遞目標路徑
+      Windows fallback command strings no longer use backslash-quote escaping, avoiding corruption of backslash-heavy paths; the Windows short path helper now uses `execFileSync` plus an environment variable for the target path
+    - Windows 上 `mpremote ... resume + run` helper 命令維持 shell command 執行路徑，修正 argv 執行在部分 Windows 環境下造成 CyberBrick Wi-Fi 掃描失敗的相容性回歸
+      On Windows, `mpremote ... resume + run` helper commands keep the shell-command execution path, fixing a compatibility regression where argv execution could break CyberBrick Wi-Fi scanning in some Windows environments
+
 ## [0.82.6] - 2026-06-04
 
 ### 🐛 修復 Bug Fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.78.x  | :white_check_mark: |
-| < 0.78  | :x:                |
+| 0.82.x  | :white_check_mark: |
+| < 0.82  | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -15,7 +15,19 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 | Package  | Severity | Advisory | Reason                                                    |
 | -------- | -------- | -------- | --------------------------------------------------------- |
-| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.78.1 |
+| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.82.9 |
+
+> **0.82.9 更新 Update**: Windows Python / pyserial helper 改用 `execFile` argv 直接執行，避免暫存腳本路徑被 short path helper 轉成 `C:\"C:\...\"` 這類無效路徑；short path helper 也會驗證輸出並在格式異常時回退原路徑。
+> Windows Python / pyserial helpers now run directly through `execFile` argv, preventing temporary script paths from being converted into malformed values such as `C:\"C:\...\"`; the short path helper also validates output and falls back to the original path when malformed.
+
+> **0.82.8 更新 Update**: Windows `mpremote` helper 命令恢復相容格式：只 quote executable、COM port 與本機檔案路徑，mpremote command tokens 不加引號，修復 v0.82.7 在 Windows 造成 Wi-Fi 掃描與 USB 上傳失敗的回歸；仍未重新引入 incomplete backslash quote。
+> Windows `mpremote` helper commands now use the compatible format again: only the executable, COM port, and local file paths are quoted while mpremote command tokens remain unquoted, fixing the v0.82.7 Windows Wi-Fi scan and USB upload regression without reintroducing incomplete backslash quoting.
+
+> **0.82.7 更新 Update**: GitHub Code scanning Alert #11 (`js/incomplete-sanitization`) 已在本地修復：CyberBrick MicroPython 上傳相關命令避免不完整 backslash quote；Windows `mpremote` helper 命令維持相容的 shell command 執行路徑，避免 Wi-Fi 掃描回歸。
+> GitHub Code scanning Alert #11 (`js/incomplete-sanitization`) has been fixed locally: CyberBrick MicroPython upload commands avoid incomplete backslash quoting; Windows `mpremote` helper commands keep the compatible shell-command path to avoid Wi-Fi scan regressions.
+
+> **0.82.6 更新 Update**: 本地 `npm audit` 顯示 0 vulnerabilities，GitHub Dependabot open alerts 為 0；目前沒有已知待處理漏洞。
+> Local `npm audit` reports 0 vulnerabilities, and GitHub Dependabot has 0 open alerts; there are no known pending vulnerabilities.
 
 > **0.78.1 更新 Update**: `qs` (`GHSA-q8mj-m7cp-5q26`, `CVE-2026-8723`) 已透過 npm override 升級至 `6.15.2` 修復，清除本地 `npm audit` 的 moderate 風險。
 > `qs` (`GHSA-q8mj-m7cp-5q26`, `CVE-2026-8723`) has been fixed by upgrading the npm override to `6.15.2`, clearing the moderate finding from local `npm audit`.
@@ -34,4 +46,4 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-04_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "singular-blockly",
-	"version": "0.82.6",
+	"version": "0.82.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "singular-blockly",
-			"version": "0.82.6",
+			"version": "0.82.9",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "singular-blockly",
 	"displayName": "Singular Blockly",
 	"description": "VS Code extension for visual Arduino & MicroPython programming with Blockly. Multi-board support (Uno, Nano, Mega, ESP32, CyberBrick), WiFi/MQTT IoT blocks, AI camera integration (Pixetto, HuskyLens), MCP server for GitHub Copilot, PlatformIO integration, and 15 languages with 99% coverage.",
-	"version": "0.82.6",
+	"version": "0.82.9",
 	"license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.105.0"

--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -93,6 +93,7 @@ export type ProgressCallback = (progress: UploadProgress) => void;
  */
 export interface CommandExecutor {
 	exec(command: string): Promise<{ stdout: string; stderr: string }>;
+	execFile?(file: string, args: string[]): Promise<{ stdout: string; stderr: string }>;
 }
 
 /**
@@ -129,6 +130,18 @@ export class MicropythonUploader {
 				const { exec } = require('child_process');
 				return new Promise((resolve, reject) => {
 					exec(command, { encoding: 'utf8' }, (error: Error | null, stdout: string, stderr: string) => {
+						if (error) {
+							reject({ error, stdout, stderr });
+						} else {
+							resolve({ stdout, stderr });
+						}
+					});
+				});
+			},
+			execFile: (file: string, args: string[]) => {
+				const { execFile } = require('child_process');
+				return new Promise((resolve, reject) => {
+					execFile(file, args, { encoding: 'utf8' }, (error: Error | null, stdout: string, stderr: string) => {
 						if (error) {
 							reject({ error, stdout, stderr });
 						} else {
@@ -192,7 +205,7 @@ export class MicropythonUploader {
 		}
 
 		try {
-			const result = await this.executor.exec(`"${pythonPath}" --version`);
+			const result = await this.execExecutable(pythonPath, ['--version']);
 			log('[blockly] PlatformIO Python 環境檢查成功', 'info', { version: result.stdout.trim() });
 			this.pythonPath = pythonPath;
 			return true;
@@ -216,7 +229,7 @@ export class MicropythonUploader {
 		}
 
 		try {
-			const result = await this.executor.exec(`"${mpremotePath}" version`);
+			const result = await this.execExecutable(mpremotePath, ['version']);
 			log('[blockly] mpremote 已安裝', 'info', { version: result.stdout.trim() });
 			this.mpremotePath = mpremotePath;
 			return true;
@@ -249,7 +262,7 @@ export class MicropythonUploader {
 			const pipPath = this.getPipPath();
 			log('[blockly] 開始安裝 mpremote', 'info', { pip: pipPath });
 
-			await this.executor.exec(`"${pipPath}" install mpremote`);
+			await this.execExecutable(pipPath, ['install', 'mpremote']);
 
 			// 驗證安裝
 			const installed = await this.checkMpremoteInstalled();
@@ -294,7 +307,7 @@ export class MicropythonUploader {
 		}
 
 		try {
-			const result = await this.executor.exec(`"${this.mpremotePath}" connect list`);
+			const result = await this.execMpremote(['connect', 'list']);
 			const ports = this.parsePortList(result.stdout);
 			const { filteredPorts, autoDetected } = this.filterPorts(ports, filter);
 
@@ -333,10 +346,7 @@ export class MicropythonUploader {
 		fs.writeFileSync(scriptFile, script, 'utf8');
 
 		try {
-			// Windows 路徑相容性：使用短路徑格式避免特殊字符問題
-			const finalScriptFile = this.getWindowsShortPath(scriptFile);
-			
-			const result = await this.execWithTimeout(`"${pythonPath}" "${finalScriptFile}"`, 10000);
+			const result = await this.execExecutable(pythonPath, [scriptFile], 10000);
 			const payload = this.parseJsonLine<{ ports?: Array<Partial<ComPortInfo>>; error?: string }>(result.stdout);
 			if (payload?.error) {
 				log('[blockly] 列出本機序列埠失敗', 'warn', { error: payload.error });
@@ -395,8 +405,8 @@ export class MicropythonUploader {
 			
 			// Windows 路徑相容性：使用短路徑格式避免特殊字符問題
 			const finalScriptFile = this.getWindowsShortPath(scriptFile);
-			
-			const command = `${this.quoteShellArg(this.mpremotePath || this.getMpremotePath())} connect ${this.quoteShellArg(normalizedPort)} resume + run ${this.quoteShellArg(finalScriptFile)}`;
+
+			const args = ['connect', normalizedPort, 'resume', '+', 'run', finalScriptFile];
 			log('[blockly] 執行 CyberBrick mpremote helper', 'debug', { port, normalizedPort, timeoutMs, mode: 'resume-run' });
 			
 			// Windows 平台重試機制：偵測 port busy 錯誤
@@ -405,7 +415,7 @@ export class MicropythonUploader {
 			
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {
 				try {
-					return await this.execWithTimeout(command, timeoutMs);
+					return await this.execMpremote(args, timeoutMs);
 				} catch (error) {
 					lastError = error;
 					const errorMsg = this.formatCommandError(error).toLowerCase();
@@ -507,9 +517,9 @@ print('OK')
 			await this.interruptDevice(normalizedPort);
 			
 			const finalSourceFile = this.getWindowsShortPath(sourceFile);
-			const command = `${this.quoteShellArg(this.mpremotePath || this.getMpremotePath())} connect ${this.quoteShellArg(normalizedPort)} resume + fs cp ${this.quoteShellArg(finalSourceFile)} :/cyberbrick_ota_agent.py`;
+			const args = ['connect', normalizedPort, 'resume', '+', 'fs', 'cp', finalSourceFile, ':/cyberbrick_ota_agent.py'];
 			log('[blockly] 部署 CyberBrick OTA agent', 'info', { port });
-			await this.execWithTimeout(command, 20000);
+			await this.execMpremote(args, 20000);
 		} catch (error) {
 			throw new Error(`CyberBrick OTA agent deploy failed: ${this.formatCommandError(error)}`);
 		} finally {
@@ -840,16 +850,39 @@ print(json.dumps(result))
 
 	/**
 	 * 跨平台 shell 參數引號處理
-	 * Windows 使用雙引號，Unix 使用單引號
+	 * Production path uses execFile argv; this is kept for injected test executors
+	 * and debug command strings.
 	 */
 	private quoteShellArg(value: string): string {
 		if (process.platform === 'win32') {
-			// Windows cmd.exe 和 PowerShell: 使用雙引號，內部雙引號轉義為 \"
-			return `"${value.replace(/"/g, '\\"')}"`;
+			// Windows paths cannot contain double quotes; reject them instead of trying to
+			// escape a value that cmd.exe may parse differently across versions.
+			if (/["\r\n]/.test(value)) {
+				throw new Error('Windows shell argument contains unsupported characters');
+			}
+			return `"${value}"`;
 		} else {
 			// Unix shells: 使用單引號，內部單引號轉義為 '\\'
 			return `'${value.replace(/'/g, `'\\''`)}'`;
 		}
+	}
+
+	private buildShellCommand(executable: string, args: string[]): string {
+		return [executable, ...args].map(value => this.quoteShellArg(value)).join(' ');
+	}
+
+	private buildWindowsMpremoteCommand(executable: string, args: string[]): string {
+		const literalArgs = new Set(['connect', 'list', 'resume', '+', 'run', 'fs', 'cp', 'cat', 'reset']);
+		return [
+			this.quoteShellArg(executable),
+			...args.map(arg => literalArgs.has(arg) || arg.startsWith(':/') ? arg : this.quoteShellArg(arg)),
+		].join(' ');
+	}
+
+	private buildMpremoteCommand(executable: string, args: string[]): string {
+		return process.platform === 'win32'
+			? this.buildWindowsMpremoteCommand(executable, args)
+			: this.buildShellCommand(executable, args);
 	}
 
 	/**
@@ -879,13 +912,27 @@ print(json.dumps(result))
 			return filePath;
 		}
 		try {
-			const { execSync } = require('child_process');
-			const shortPath = execSync(`for %I in ("${filePath}") do @echo %~sI`, { encoding: 'utf8' }).trim();
-			return (shortPath && shortPath !== filePath) ? shortPath : filePath;
+			const { execFileSync } = require('child_process');
+			const shortPath = execFileSync(
+				process.env.ComSpec || 'cmd.exe',
+				['/d', '/c', 'for %I in ("%SINGULAR_BLOCKLY_SHORT_PATH_TARGET%") do @echo %~sI'],
+				{
+					encoding: 'utf8',
+					env: {
+						...process.env,
+						SINGULAR_BLOCKLY_SHORT_PATH_TARGET: filePath,
+					},
+				}
+			).trim();
+			return this.isUsableWindowsPath(shortPath) && shortPath !== filePath ? shortPath : filePath;
 		} catch {
 			// 取得短路徑失敗時使用原路徑
 			return filePath;
 		}
+	}
+
+	private isUsableWindowsPath(filePath: string): boolean {
+		return /^[A-Za-z]:\\[^"]+$/.test(filePath) || /^\\\\[^"]+$/.test(filePath);
 	}
 
 	private formatCommandError(error: unknown): string {
@@ -1128,10 +1175,8 @@ print(json.dumps(result))
 		fs.writeFileSync(scriptFile, serialScript, 'utf8');
 
 		try {
-			const finalScriptFile = this.getWindowsShortPath(scriptFile);
-			const command = `"${pythonPath}" "${finalScriptFile}"`;
 			log('[blockly] 使用 pyserial 發送中斷信號', 'debug', { port, scriptFile });
-			const result = await this.execWithTimeout(command, 8000);
+			const result = await this.execExecutable(pythonPath, [scriptFile], 8000);
 
 			if (result.stdout.includes('OK')) {
 				log('[blockly] 程式已中斷，REPL 準備就緒', 'info');
@@ -1145,8 +1190,8 @@ print(json.dumps(result))
 			log('[blockly] pyserial 中斷失敗，嘗試硬體重置', 'warn', error);
 			// 備用方案：使用 mpremote 硬體重置
 			try {
-				const resetCommand = `"${this.mpremotePath}" connect ${port} reset`;
-				await this.execWithTimeout(resetCommand, 5000);
+				const normalizedPort = this.normalizeCOMPort(port);
+				await this.execMpremote(['connect', normalizedPort, 'reset'], 5000);
 				await this.delay(2000);
 			} catch (resetError) {
 				log('[blockly] 硬體重置也失敗', 'error', resetError);
@@ -1175,13 +1220,34 @@ print(json.dumps(result))
 	 * @param timeoutMs 超時毫秒數
 	 */
 	private async execWithTimeout(command: string, timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
+		return this.runWithTimeout(() => this.executor.exec(command), timeoutMs);
+	}
+
+	private async execExecutable(executable: string, args: string[], timeoutMs?: number): Promise<{ stdout: string; stderr: string }> {
+		const run = () => {
+			if (this.executor.execFile) {
+				return this.executor.execFile(executable, args);
+			}
+			return this.executor.exec(this.buildShellCommand(executable, args));
+		};
+
+		if (timeoutMs === undefined) {
+			return run();
+		}
+
+		return this.runWithTimeout(run, timeoutMs);
+	}
+
+	private async runWithTimeout(
+		run: () => Promise<{ stdout: string; stderr: string }>,
+		timeoutMs: number
+	): Promise<{ stdout: string; stderr: string }> {
 		return new Promise((resolve, reject) => {
 			const timeoutId = setTimeout(() => {
 				reject(new Error(`指令執行超時 (${timeoutMs}ms)`));
 			}, timeoutMs);
 
-			this.executor
-				.exec(command)
+			run()
 				.then(result => {
 					clearTimeout(timeoutId);
 					resolve(result);
@@ -1191,6 +1257,15 @@ print(json.dumps(result))
 					reject(error);
 				});
 		});
+	}
+
+	private async execMpremote(args: string[], timeoutMs?: number): Promise<{ stdout: string; stderr: string }> {
+		const mpremotePath = this.mpremotePath || this.getMpremotePath();
+		if (process.platform === 'win32') {
+			const command = this.buildMpremoteCommand(mpremotePath, args);
+			return timeoutMs === undefined ? this.executor.exec(command) : this.execWithTimeout(command, timeoutMs);
+		}
+		return this.execExecutable(mpremotePath, args, timeoutMs);
 	}
 
 	/**
@@ -1256,16 +1331,18 @@ print(json.dumps(result))
 			// 在 interruptDevice 之後，裝置已經在正常 REPL 模式
 			const normalizedPort = this.normalizeCOMPort(port);
 			const finalTempFile = this.getWindowsShortPath(tempFile);
-			const command = `${this.quoteShellArg(this.mpremotePath || this.getMpremotePath())} connect ${this.quoteShellArg(normalizedPort)} resume + fs cp ${this.quoteShellArg(finalTempFile)} :${DEVICE_PATH}`;
+			const args = ['connect', normalizedPort, 'resume', '+', 'fs', 'cp', finalTempFile, `:${DEVICE_PATH}`];
+			const mpremotePath = this.mpremotePath || this.getMpremotePath();
+			const command = this.buildMpremoteCommand(mpremotePath, args);
 			log('[blockly] 執行上傳指令', 'debug', { port, normalizedPort, command });
-			
+
 			// Windows 平台重試機制：偵測 port busy 錯誤
 			const maxRetries = process.platform === 'win32' ? 3 : 1;
 			let lastError: unknown;
-			
+
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {
 				try {
-					await this.executor.exec(command);
+					await this.execMpremote(args);
 					return; // 成功上傳
 				} catch (error) {
 					lastError = error;
@@ -1306,9 +1383,11 @@ print(json.dumps(result))
 	private async restartDevice(port: string): Promise<void> {
 		// 使用 resume + 確保不會觸發額外的 soft-reset
 		const normalizedPort = this.normalizeCOMPort(port);
-		const command = `${this.quoteShellArg(this.mpremotePath || this.getMpremotePath())} connect ${this.quoteShellArg(normalizedPort)} resume + reset`;
+		const args = ['connect', normalizedPort, 'resume', '+', 'reset'];
+		const mpremotePath = this.mpremotePath || this.getMpremotePath();
+		const command = this.buildMpremoteCommand(mpremotePath, args);
 		log('[blockly] 執行重啟指令', 'debug', { port, normalizedPort, command });
-		await this.executor.exec(command);
+		await this.execMpremote(args);
 	}
 
 	/**
@@ -1325,9 +1404,12 @@ print(json.dumps(result))
 		}
 
 		try {
-			const command = `"${this.mpremotePath}" connect ${port} fs cat :${DEVICE_PATH}`;
+			const normalizedPort = this.normalizeCOMPort(port);
+			const args = ['connect', normalizedPort, 'fs', 'cat', `:${DEVICE_PATH}`];
+			const mpremotePath = this.mpremotePath || this.getMpremotePath();
+			const command = this.buildMpremoteCommand(mpremotePath, args);
 			log('[blockly] 讀取裝置程式', 'debug', { command });
-			const result = await this.executor.exec(command);
+			const result = await this.execMpremote(args);
 			return result.stdout;
 		} catch (error) {
 			log('[blockly] 讀取裝置程式失敗', 'warn', error);

--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -850,8 +850,8 @@ print(json.dumps(result))
 
 	/**
 	 * 跨平台 shell 參數引號處理
-	 * Production path uses execFile argv; this is kept for injected test executors
-	 * and debug command strings.
+	 * Python helpers and non-Windows mpremote use execFile argv when available;
+	 * Windows mpremote still uses shell commands for resume + run / fs cp compatibility.
 	 */
 	private quoteShellArg(value: string): string {
 		if (process.platform === 'win32') {

--- a/src/test/services/micropythonUploaderCyberBrickHelpers.test.ts
+++ b/src/test/services/micropythonUploaderCyberBrickHelpers.test.ts
@@ -17,11 +17,91 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 		return uploader;
 	}
 
-	test('lists CyberBrick USB ports via PlatformIO Python without depending on mpremote', async () => {
-		let helperScript = '';
+	function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
+		const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+		Object.defineProperty(process, 'platform', { value: platform });
+		try {
+			return callback();
+		} finally {
+			if (originalPlatform) {
+				Object.defineProperty(process, 'platform', originalPlatform);
+			}
+		}
+	}
+
+	test('builds Windows fallback shell commands without corrupting backslash paths', () => {
+		const uploader = createUploader({
+			exec: async () => ({ stdout: '', stderr: '' }),
+		});
+		const buildWindowsMpremoteCommand = (uploader as unknown as { buildWindowsMpremoteCommand(executable: string, args: string[]): string }).buildWindowsMpremoteCommand.bind(uploader);
+		const quoteShellArg = (uploader as unknown as { quoteShellArg(value: string): string }).quoteShellArg.bind(uploader);
+
+		withPlatform('win32', () => {
+			assert.strictEqual(
+				buildWindowsMpremoteCommand(
+					'C:\\Users\\Alice Test\\.platformio\\penv\\Scripts\\mpremote.exe',
+					['connect', 'com3', 'resume', '+', 'run', 'C:\\Users\\Alice Test\\AppData\\Local\\Temp\\helper.py']
+				),
+				'"C:\\Users\\Alice Test\\.platformio\\penv\\Scripts\\mpremote.exe" connect "com3" resume + run "C:\\Users\\Alice Test\\AppData\\Local\\Temp\\helper.py"'
+			);
+			assert.throws(() => quoteShellArg('C:\\Temp\\a"b.py'), /unsupported characters/);
+		});
+	});
+
+	test('uses Windows shell execution for mpremote helper commands', async () => {
+		const commands: string[] = [];
+		const execFileCalls: Array<{ file: string; args: string[] }> = [];
 		const uploader = createUploader({
 			exec: async command => {
-				const scriptPath = command.match(/"([^"]*cyberbrick_serial_ports_[^"]*\.py)"$/)?.[1] || command.match(/"([^"]*cyberbrick_serial_ports_[^"]*\.py)"/)?.[1];
+				commands.push(command);
+				return { stdout: 'OK\n', stderr: '' };
+			},
+			execFile: async (file, args) => {
+				execFileCalls.push({ file, args });
+				return { stdout: 'execFile\n', stderr: '' };
+			},
+		});
+		const execMpremote = (uploader as unknown as { execMpremote(args: string[], timeoutMs?: number): Promise<{ stdout: string; stderr: string }> }).execMpremote.bind(uploader);
+
+		await withPlatform('win32', () =>
+			execMpremote(['connect', 'COM3', 'resume', '+', 'run', 'C:\\Users\\Alice Test\\AppData\\Local\\Temp\\helper.py'], 10000)
+		);
+
+		assert.strictEqual(execFileCalls.length, 0, 'Windows mpremote commands should avoid execFile for compatibility with resume + run parsing');
+		assert.strictEqual(commands.length, 1);
+		assert.ok(commands[0].includes('connect "COM3" resume + run'));
+		assert.ok(commands[0].includes('"C:\\Users\\Alice Test\\AppData\\Local\\Temp\\helper.py"'));
+	});
+
+	test('falls back when Windows short path output is malformed', () => {
+		const uploader = createUploader({
+			exec: async () => ({ stdout: '', stderr: '' }),
+		});
+		const getWindowsShortPath = (uploader as unknown as { getWindowsShortPath(filePath: string): string }).getWindowsShortPath.bind(uploader);
+		const childProcess = require('child_process') as { execFileSync: (...args: unknown[]) => string };
+		const originalExecFileSync = childProcess.execFileSync;
+		const originalPath = 'C:\\Users\\Alice Test\\AppData\\Local\\Temp\\blockly_interrupt.py';
+
+		childProcess.execFileSync = () => 'C:\\"C:\\Users\\ALICE~1\\AppData\\Local\\Temp\\blockly_interrupt.py\\""';
+		try {
+			withPlatform('win32', () => {
+				assert.strictEqual(getWindowsShortPath(originalPath), originalPath);
+			});
+		} finally {
+			childProcess.execFileSync = originalExecFileSync;
+		}
+	});
+
+	test('lists CyberBrick USB ports via PlatformIO Python without depending on mpremote', async () => {
+		let helperScript = '';
+		const execFileCalls: Array<{ file: string; args: string[] }> = [];
+		const uploader = createUploader({
+			exec: async command => {
+				throw new Error(`serial port probe should use execFile when available: ${command}`);
+			},
+			execFile: async (file, args) => {
+				execFileCalls.push({ file, args });
+				const scriptPath = args[0];
 				assert.ok(scriptPath, 'serial port probe should run a temporary Python helper script');
 				helperScript = fs.readFileSync(scriptPath, 'utf8');
 				return {
@@ -36,8 +116,37 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 		assert.strictEqual(result.autoDetected, '/dev/cu.usbmodem1201');
 		assert.strictEqual(result.ports.length, 1);
 		assert.strictEqual(result.ports[0].serialNumber, 'ABC123');
+		assert.deepStrictEqual(execFileCalls.map(call => call.file), ['/mock/python']);
 		assert.ok(helperScript.includes('from serial.tools import list_ports'));
 		assert.ok(helperScript.includes("getattr(info, 'serial_number', None)"));
+	});
+
+	test('runs Windows pyserial interrupt helper through execFile argv', async () => {
+		const commands: string[] = [];
+		const execFileCalls: Array<{ file: string; args: string[] }> = [];
+		const uploader = createUploader({
+			exec: async command => {
+				commands.push(command);
+				return { stdout: '', stderr: '' };
+			},
+			execFile: async (file, args) => {
+				execFileCalls.push({ file, args });
+				const scriptPath = args[0];
+				assert.ok(scriptPath.endsWith('blockly_interrupt.py'), 'interrupt helper should pass the script path as argv');
+				assert.strictEqual(scriptPath.includes('"'), false);
+				assert.strictEqual(scriptPath.includes('C:\\"'), false);
+				const script = fs.readFileSync(scriptPath, 'utf8');
+				assert.ok(script.includes('serial.Serial("COM48", 115200, timeout=2)'));
+				return { stdout: 'OK\n', stderr: '' };
+			},
+		});
+		const interruptApi = uploader as unknown as { interruptDevice(port: string): Promise<void>; delay(ms: number): Promise<void> };
+		interruptApi.delay = async () => undefined;
+
+		await withPlatform('win32', () => interruptApi.interruptDevice('com48'));
+
+		assert.strictEqual(commands.length, 0, 'pyserial interrupt should not use shell commands when execFile is available');
+		assert.deepStrictEqual(execFileCalls.map(call => call.file), ['/mock/python']);
 	});
 
 	test('interrupts the running program and runs temporary helper scripts with mpremote resume + run', async () => {
@@ -46,7 +155,7 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 			exec: async command => {
 				commands.push(command);
 				if (command.includes('blockly_interrupt.py')) {
-					const scriptPath = command.match(/"([^"]*blockly_interrupt\.py)"/)?.[1];
+					const scriptPath = command.match(/["']([^"']*blockly_interrupt\.py)["']/)?.[1];
 					assert.ok(scriptPath, 'interrupt command should include the temporary script path');
 					const script = fs.readFileSync(scriptPath, 'utf8');
 					assert.ok(script.includes('try:\n    s = serial.Serial("/dev/cu.usbmodem1201", 115200, timeout=2)'));
@@ -63,7 +172,7 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 		assert.strictEqual(commands.length, 2);
 		assert.ok(commands[1].includes('cyberbrick_exec_'), 'Wi-Fi scan should run through a temporary helper script');
 		assert.ok(commands[0].includes('blockly_interrupt.py'));
-		assert.ok(commands[1].includes(" connect '/dev/cu.usbmodem1201' resume + run "));
+		assert.ok(commands[1].includes("'connect' '/dev/cu.usbmodem1201' 'resume' '+' 'run' "));
 		assert.strictEqual(commands[1].includes(' exec '), false);
 	});
 
@@ -129,9 +238,9 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 
 		assert.strictEqual(commands.length, 2);
 		assert.ok(commands[0].includes('blockly_interrupt.py'));
-		assert.ok(commands[1].includes(" connect '/dev/cu.usbmodem1201' resume + fs cp "));
+		assert.ok(commands[1].includes("'connect' '/dev/cu.usbmodem1201' 'resume' '+' 'fs' 'cp' "));
 		assert.ok(commands[1].includes(':/cyberbrick_ota_agent.py'));
-		assert.deepStrictEqual(commands[1].match(/:\/[^\s]+/g), [':/cyberbrick_ota_agent.py']);
+		assert.deepStrictEqual(commands[1].match(/:\/[^\s']+/g), [':/cyberbrick_ota_agent.py']);
 	});
 
 	test('builds OTA agent source without patch artifacts and with background startup', () => {


### PR DESCRIPTION
## 變更摘要 Summary

修復 CodeQL quote handling 修正後造成的 Windows CyberBrick USB 上傳與 Wi-Fi 掃描回歸。Python / pyserial helper 改用 `execFile` argv 執行，避免暫存腳本路徑被 short path helper 轉成 `C:\"C:\...\"`；Windows `mpremote` helper 保留相容的 shell token 格式，同時避免重新引入 incomplete backslash quote。

## 變更類型 Type of Change

- [x] 🐛 Bug 修復 (non-breaking change which fixes an issue)
- [x] 🔒 安全修復相容性補強 (keeps CodeQL Alert #11 fix without Windows regression)
- [x] 📝 文件更新 (CHANGELOG / SECURITY / version notes)

## 變更內容 Changes

- Python / pyserial helper commands now use `execFile` argv for direct script execution.
- Windows short path helper now validates output and falls back when `cmd` returns malformed quoted paths.
- Windows `mpremote` helper commands keep the compatible shell form for `resume + run` and `fs cp` token parsing.
- Added regression tests for malformed Windows short paths, pyserial argv execution, and Windows mpremote command formatting.
- Bumped package version to `0.82.9` for manual VSIX validation.

## 測試計劃 Test Plan

- [x] macOS 手動測試通過：USB 上傳與 Wi-Fi 掃描（使用者驗證）
- [x] Windows 手動測試通過：USB 上傳與 Wi-Fi 掃描（使用者驗證）
- [x] `npx eslint src/services/micropythonUploader.ts src/test/services/micropythonUploaderCyberBrickHelpers.test.ts`
- [x] `npm run compile-tests`
- [x] `git diff --check`
- [x] `npm audit --audit-level=low` → 0 vulnerabilities
- [x] `npm test` → 892 passing, 1 pending
- [x] Packaged local test VSIX: `singular-blockly-0.82.9.vsix`

## 發布狀態 Release Status

尚未 tag、merge、GitHub Release 或 Marketplace 發布；此 PR 先用於確認 CI / CodeQL / code scanning 是否通過。