### PR TITLE
fix(services): split Windows mpremote fs cp execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.82.10] - 2026-06-04
+
+### 🐛 修復 Bug Fixes
+
+- **CyberBrick Windows USB 上傳 fs cp argv 分流** (CyberBrick Windows USB upload fs cp argv split)
+    - Windows 上 `mpremote ... fs cp` 上傳本機暫存檔時改用 `execFile` argv 執行，避免 shell 解析含空格或反斜線的暫存路徑時產生 `檔案名稱、目錄名稱或磁碟區標籤語法錯誤。`
+      On Windows, `mpremote ... fs cp` now uploads local temporary files through `execFile` argv to avoid shell parsing failures for paths with spaces or backslashes, including "filename, directory name, or volume label syntax is incorrect."
+    - 保留前次修復驗證過的 Windows `resume + run` helper shell 執行路徑，避免再次破壞 Wi-Fi 掃描與 OTA 設定檢查
+      Keeps the previously verified Windows `resume + run` helper shell path to avoid regressing Wi-Fi scan and OTA configuration checks.
+    - 新增 Windows 分流測試，鎖定 helper run 仍走 shell、USB `fs cp` 上傳走 argv
+      Added Windows split-path tests to lock helper run on shell while USB `fs cp` upload uses argv.
+
 ## [0.82.9] - 2026-06-04
 
 ### 🐛 修復 Bug Fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,10 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 | Package  | Severity | Advisory | Reason                                                    |
 | -------- | -------- | -------- | --------------------------------------------------------- |
-| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.82.9 |
+| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.82.10 |
+
+> **0.82.10 更新 Update**: Windows `mpremote ... fs cp` USB 上傳改用 `execFile` argv 執行，避免 shell 解析本機暫存路徑造成「檔案名稱、目錄名稱或磁碟區標籤語法錯誤」；Windows `resume + run` helper 維持前次驗證過的 shell 相容路徑。
+> Windows `mpremote ... fs cp` USB uploads now run through `execFile` argv to avoid shell parsing failures for local temporary paths; Windows `resume + run` helpers keep the previously verified shell-compatible path.
 
 > **0.82.9 更新 Update**: Windows Python / pyserial helper 改用 `execFile` argv 直接執行，避免暫存腳本路徑被 short path helper 轉成 `C:\"C:\...\"` 這類無效路徑；short path helper 也會驗證輸出並在格式異常時回退原路徑。
 > Windows Python / pyserial helpers now run directly through `execFile` argv, preventing temporary script paths from being converted into malformed values such as `C:\"C:\...\"`; the short path helper also validates output and falls back to the original path when malformed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "singular-blockly",
-	"version": "0.82.9",
+	"version": "0.82.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "singular-blockly",
-			"version": "0.82.9",
+			"version": "0.82.10",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "singular-blockly",
 	"displayName": "Singular Blockly",
 	"description": "VS Code extension for visual Arduino & MicroPython programming with Blockly. Multi-board support (Uno, Nano, Mega, ESP32, CyberBrick), WiFi/MQTT IoT blocks, AI camera integration (Pixetto, HuskyLens), MCP server for GitHub Copilot, PlatformIO integration, and 15 languages with 99% coverage.",
-	"version": "0.82.9",
+	"version": "0.82.10",
 	"license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.105.0"

--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -402,9 +402,9 @@ export class MicropythonUploader {
 			}
 			
 			const normalizedPort = this.normalizeCOMPort(port);
-			
-			// Windows 路徑相容性：使用短路徑格式避免特殊字符問題
-			const finalScriptFile = this.getWindowsShortPath(scriptFile);
+
+			// Windows shell-mode mpremote helper uses short paths for compatibility.
+			const finalScriptFile = this.getMpremoteLocalPath(scriptFile, 'shell');
 
 			const args = ['connect', normalizedPort, 'resume', '+', 'run', finalScriptFile];
 			log('[blockly] 執行 CyberBrick mpremote helper', 'debug', { port, normalizedPort, timeoutMs, mode: 'resume-run' });
@@ -515,11 +515,11 @@ print('OK')
 		const normalizedPort = this.normalizeCOMPort(port);
 		try {
 			await this.interruptDevice(normalizedPort);
-			
-			const finalSourceFile = this.getWindowsShortPath(sourceFile);
+
+			const finalSourceFile = this.getMpremoteLocalPath(sourceFile, 'argv');
 			const args = ['connect', normalizedPort, 'resume', '+', 'fs', 'cp', finalSourceFile, ':/cyberbrick_ota_agent.py'];
 			log('[blockly] 部署 CyberBrick OTA agent', 'info', { port });
-			await this.execMpremote(args, 20000);
+			await this.execMpremote(args, 20000, 'argv');
 		} catch (error) {
 			throw new Error(`CyberBrick OTA agent deploy failed: ${this.formatCommandError(error)}`);
 		} finally {
@@ -850,8 +850,8 @@ print(json.dumps(result))
 
 	/**
 	 * 跨平台 shell 參數引號處理
-	 * Python helpers and non-Windows mpremote use execFile argv when available;
-	 * Windows mpremote still uses shell commands for resume + run / fs cp compatibility.
+	 * Python helpers and Windows fs cp uploads use execFile argv when available;
+	 * Windows resume + run helpers still use shell commands for compatibility.
 	 */
 	private quoteShellArg(value: string): string {
 		if (process.platform === 'win32') {
@@ -883,6 +883,10 @@ print(json.dumps(result))
 		return process.platform === 'win32'
 			? this.buildWindowsMpremoteCommand(executable, args)
 			: this.buildShellCommand(executable, args);
+	}
+
+	private getMpremoteLocalPath(filePath: string, windowsExecution: 'shell' | 'argv'): string {
+		return process.platform === 'win32' && windowsExecution === 'argv' ? filePath : this.getWindowsShortPath(filePath);
 	}
 
 	/**
@@ -1259,9 +1263,13 @@ print(json.dumps(result))
 		});
 	}
 
-	private async execMpremote(args: string[], timeoutMs?: number): Promise<{ stdout: string; stderr: string }> {
+	private async execMpremote(
+		args: string[],
+		timeoutMs?: number,
+		windowsExecution: 'shell' | 'argv' = 'shell'
+	): Promise<{ stdout: string; stderr: string }> {
 		const mpremotePath = this.mpremotePath || this.getMpremotePath();
-		if (process.platform === 'win32') {
+		if (process.platform === 'win32' && windowsExecution === 'shell') {
 			const command = this.buildMpremoteCommand(mpremotePath, args);
 			return timeoutMs === undefined ? this.executor.exec(command) : this.execWithTimeout(command, timeoutMs);
 		}
@@ -1330,11 +1338,11 @@ print(json.dumps(result))
 			// 使用 resume + 避免觸發 soft-reset（這會導致程式重新執行）
 			// 在 interruptDevice 之後，裝置已經在正常 REPL 模式
 			const normalizedPort = this.normalizeCOMPort(port);
-			const finalTempFile = this.getWindowsShortPath(tempFile);
+			const finalTempFile = this.getMpremoteLocalPath(tempFile, 'argv');
 			const args = ['connect', normalizedPort, 'resume', '+', 'fs', 'cp', finalTempFile, `:${DEVICE_PATH}`];
 			const mpremotePath = this.mpremotePath || this.getMpremotePath();
 			const command = this.buildMpremoteCommand(mpremotePath, args);
-			log('[blockly] 執行上傳指令', 'debug', { port, normalizedPort, command });
+			log('[blockly] 執行上傳指令', 'debug', { port, normalizedPort, command, mode: 'argv-fs-cp' });
 
 			// Windows 平台重試機制：偵測 port busy 錯誤
 			const maxRetries = process.platform === 'win32' ? 3 : 1;
@@ -1342,7 +1350,7 @@ print(json.dumps(result))
 
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {
 				try {
-					await this.execMpremote(args);
+					await this.execMpremote(args, undefined, 'argv');
 					return; // 成功上傳
 				} catch (error) {
 					lastError = error;

--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -850,7 +850,7 @@ print(json.dumps(result))
 
 	/**
 	 * 跨平台 shell 參數引號處理
-	 * Python helpers and Windows fs cp uploads use execFile argv when available;
+	 * Python helpers, non-Windows mpremote, and Windows fs cp uploads use execFile argv when available;
 	 * Windows resume + run helpers still use shell commands for compatibility.
 	 */
 	private quoteShellArg(value: string): string {

--- a/src/test/services/micropythonUploaderCyberBrickHelpers.test.ts
+++ b/src/test/services/micropythonUploaderCyberBrickHelpers.test.ts
@@ -29,6 +29,18 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 		}
 	}
 
+	async function withPlatformAsync<T>(platform: NodeJS.Platform, callback: () => Promise<T>): Promise<T> {
+		const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+		Object.defineProperty(process, 'platform', { value: platform });
+		try {
+			return await callback();
+		} finally {
+			if (originalPlatform) {
+				Object.defineProperty(process, 'platform', originalPlatform);
+			}
+		}
+	}
+
 	test('builds Windows fallback shell commands without corrupting backslash paths', () => {
 		const uploader = createUploader({
 			exec: async () => ({ stdout: '', stderr: '' }),
@@ -71,6 +83,40 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 		assert.strictEqual(commands.length, 1);
 		assert.ok(commands[0].includes('connect "COM3" resume + run'));
 		assert.ok(commands[0].includes('"C:\\Users\\Alice Test\\AppData\\Local\\Temp\\helper.py"'));
+	});
+
+	test('uses Windows argv execution for mpremote fs cp commands', async () => {
+		const commands: string[] = [];
+		const execFileCalls: Array<{ file: string; args: string[] }> = [];
+		const uploader = createUploader({
+			exec: async command => {
+				commands.push(command);
+				return { stdout: 'shell\n', stderr: '' };
+			},
+			execFile: async (file, args) => {
+				execFileCalls.push({ file, args });
+				return { stdout: 'argv\n', stderr: '' };
+			},
+		});
+		const execMpremote = (uploader as unknown as {
+			execMpremote(args: string[], timeoutMs?: number, windowsExecution?: 'shell' | 'argv'): Promise<{ stdout: string; stderr: string }>;
+		}).execMpremote.bind(uploader);
+		const args = [
+			'connect',
+			'COM7',
+			'resume',
+			'+',
+			'fs',
+			'cp',
+			'C:\\Users\\Alice Test\\AppData\\Local\\Temp\\blockly_upload.py',
+			':/app/rc_main.py',
+		];
+
+		const result = await withPlatformAsync('win32', () => execMpremote(args, undefined, 'argv'));
+
+		assert.strictEqual(result.stdout, 'argv\n');
+		assert.strictEqual(commands.length, 0, 'Windows fs cp uploads should avoid shell parsing of local paths');
+		assert.deepStrictEqual(execFileCalls, [{ file: '/mock/mpremote', args }]);
 	});
 
 	test('falls back when Windows short path output is malformed', () => {
@@ -355,6 +401,57 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 			'configure helper should update cached agent OTA_TOKEN to prevent token mismatch after re-provisioning'
 		);
 		assert.strictEqual(commands.length, 2);
+	});
+
+	test('keeps Windows helper run on shell but uploads rc_main.py through argv fs cp', async () => {
+		const commands: string[] = [];
+		const mpremoteExecFileCalls: string[][] = [];
+		let uploadedCode = '';
+		const uploader = createUploader({
+			exec: async command => {
+				commands.push(command);
+				if (command.includes('cyberbrick_exec_')) {
+					return { stdout: 'NO\n', stderr: '' };
+				}
+				return { stdout: '', stderr: '' };
+			},
+			execFile: async (file, args) => {
+				if (file === '/mock/python') {
+					const scriptPath = args[0];
+					assert.ok(scriptPath.endsWith('blockly_interrupt.py'), 'interrupt helper should still run through Python argv');
+					return { stdout: 'OK\n', stderr: '' };
+				}
+				if (file === '/mock/mpremote') {
+					mpremoteExecFileCalls.push(args);
+					if (args.includes('fs') && args.includes('cp')) {
+						const scriptPath = args[6];
+						assert.strictEqual(scriptPath.includes('"'), false, 'fs cp local path should be passed as a raw argv value');
+						uploadedCode = fs.readFileSync(scriptPath, 'utf8');
+					}
+					return { stdout: '', stderr: '' };
+				}
+				throw new Error(`unexpected execFile: ${file}`);
+			},
+		});
+		const uploadApi = uploader as unknown as { uploadCode(code: string, port: string): Promise<void>; delay(ms: number): Promise<void> };
+		uploadApi.delay = async () => undefined;
+
+		await withPlatformAsync('win32', () => uploadApi.uploadCode('print("student")\n', 'com7'));
+
+		assert.ok(commands.some(command => command.includes('connect "COM7" resume + run')), 'OTA check helper should keep the Windows shell resume + run path');
+		assert.strictEqual(commands.some(command => command.includes(' fs cp ')), false, 'USB fs cp upload should not be executed through a shell command on Windows');
+		assert.deepStrictEqual(mpremoteExecFileCalls, [[
+			'connect',
+			'COM7',
+			'resume',
+			'+',
+			'fs',
+			'cp',
+			mpremoteExecFileCalls[0][6],
+			':/app/rc_main.py',
+		]]);
+		assert.ok(uploadedCode.includes('print("student")'), 'should preserve user code in the uploaded file');
+		assert.strictEqual(uploadedCode.includes('_singular_blockly_ota_agent.start_background'), false, 'NO OTA config should keep the upload clean');
 	});
 
 	test('redacts secret-bearing OTA configuration helper failures', async () => {


### PR DESCRIPTION
## 變更摘要 Summary

修正部分 Windows 電腦 CyberBrick USB 上傳失敗的問題。log 解碼後對應 Windows 錯誤「檔案名稱、目錄名稱或磁碟區標籤語法錯誤」，原因集中在 `mpremote ... fs cp` 透過 shell 執行時解析本機暫存檔路徑失敗。

這個 PR **刻意只分流 `fs cp` 上傳路徑**：Windows `mpremote ... fs cp` 改用 `execFile` argv，避免 shell 解析本機檔案路徑；Windows `resume + run` helper 仍維持前次驗證過的 shell 執行路徑，避免再次破壞 Wi-Fi 掃描與 OTA 設定檢查。

## Reviewer 注意事項 Review Notes

請不要把 Windows `mpremote` 執行方式整理成單一路徑。這裡的差異是刻意保留的相容性邊界：

- `resume + run` helper：Windows 保持 shell command，這是前次修復後已驗證可讓 Wi-Fi 掃描與 OTA 設定檢查正常的路徑。
- `fs cp` USB 上傳：Windows 改用 `execFile` argv，避免 shell 對含空格、反斜線或特殊字元的本機暫存路徑解析失敗。
- 請避免建議「全部改成 argv」或「全部回到 shell」；這兩種方向都曾在不同 Windows 情境造成回歸風險。

## 變更內容 Changes

- 新增 `execMpremote(..., windowsExecution)` 分流參數，Windows 預設仍可保留 shell helper 相容性。
- USB `uploadCode()` 和 OTA agent `fs cp` 部署改用 argv 執行。
- `runCyberBrickPython()` 的 `resume + run` helper 維持 Windows shell mode。
- 新增 Windows 回歸測試，鎖定 helper run 走 shell、USB `fs cp` 走 argv。
- 版本更新至 `0.82.10`，並更新 CHANGELOG / SECURITY 說明。

## 測試計劃 Test Plan

- [x] `npx eslint src/services/micropythonUploader.ts src/test/services/micropythonUploaderCyberBrickHelpers.test.ts`
- [x] `npm run compile-tests`
- [x] `git diff --check`
- [x] `npm audit --audit-level=low`：0 vulnerabilities
- [x] `npm test`：894 passing, 1 pending
- [x] `npx @vscode/vsce package --out singular-blockly-0.82.10.vsix`
- [x] VSIX 包內版本確認：`singular-blockly@0.82.10`
- [x] 手動測試：2 台 Windows 電腦通過
- [x] 手動測試：1 台 macOS 電腦通過

## VSIX 驗證 VSIX Verification

- Local test package: `singular-blockly-0.82.10.vsix`
- SHA256: `05795c08bf716e89d97222dcd4e41e3ecc0ec0903a9f44f4962c0c0b53813cb3`
