### PR TITLE
fix(cyberbrick): prepare mpremote before port pre-detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.82.11] - 2026-06-04
+
+### 🐛 修復 Bug Fixes
+
+- **CyberBrick mpremote 自動安裝與 USB port 預掃描修復** (CyberBrick mpremote auto-install and USB port pre-detect fix)
+    - CyberBrick USB 上傳在未指定 port 時，會先沿用 PlatformIO `penv` 的 `mpremote` 自動安裝流程，再執行 USB port 預掃描；避免新環境尚未安裝 `mpremote` 時被誤判成找不到 COM port 並導致上傳失敗
+      CyberBrick USB upload now reuses the PlatformIO `penv`-based `mpremote` auto-install flow before USB port pre-detection when no port is specified; this avoids treating a fresh environment without `mpremote` as "no COM port found" and failing upload.
+    - OTA 設定頁的 USB port 清單同樣會先確認 `mpremote` 可用；若安裝失敗，會回報明確的 `mpremote-unavailable` 錯誤，而不是靜默顯示空 port 清單
+      The OTA settings USB port list also ensures `mpremote` is available first; installation failures now report an explicit `mpremote-unavailable` error instead of silently showing an empty port list.
+    - 保留 v0.82.10 已驗證的 Windows `fs cp` argv 分流與 `resume + run` shell 相容路徑，避免影響已通過 Windows/macOS 手動測試的上傳與 Wi-Fi 掃描行為
+      Preserves the Windows `fs cp` argv split and `resume + run` shell-compatible path verified in v0.82.10 to avoid regressing the manually tested Windows/macOS upload and Wi-Fi scan behavior.
+
 ## [0.82.10] - 2026-06-04
 
 ### 🐛 修復 Bug Fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,10 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 | Package  | Severity | Advisory | Reason                                                    |
 | -------- | -------- | -------- | --------------------------------------------------------- |
-| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.82.10 |
+| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.82.11 |
+
+> **0.82.11 更新 Update**: CyberBrick USB port 預掃描與 OTA 設定頁 USB port 清單會先沿用 PlatformIO `penv` 的 `mpremote` 自動安裝流程；缺少 `mpremote` 不再被靜默誤判成找不到 COM port，且未改動 v0.82.10 已驗證的 Windows `fs cp` / `resume + run` 命令分流。
+> CyberBrick USB port pre-detection and the OTA settings USB port list now reuse the PlatformIO `penv`-based `mpremote` auto-install flow first; missing `mpremote` is no longer silently treated as no COM port found, and the Windows `fs cp` / `resume + run` command split verified in v0.82.10 is unchanged.
 
 > **0.82.10 更新 Update**: Windows `mpremote ... fs cp` USB 上傳改用 `execFile` argv 執行，避免 shell 解析本機暫存路徑造成「檔案名稱、目錄名稱或磁碟區標籤語法錯誤」；Windows `resume + run` helper 維持前次驗證過的 shell 相容路徑。
 > Windows `mpremote ... fs cp` USB uploads now run through `execFile` argv to avoid shell parsing failures for local temporary paths; Windows `resume + run` helpers keep the previously verified shell-compatible path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "singular-blockly",
-	"version": "0.82.10",
+	"version": "0.82.11",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "singular-blockly",
-			"version": "0.82.10",
+			"version": "0.82.11",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "singular-blockly",
 	"displayName": "Singular Blockly",
 	"description": "VS Code extension for visual Arduino & MicroPython programming with Blockly. Multi-board support (Uno, Nano, Mega, ESP32, CyberBrick), WiFi/MQTT IoT blocks, AI camera integration (Pixetto, HuskyLens), MCP server for GitHub Copilot, PlatformIO integration, and 15 languages with 99% coverage.",
-	"version": "0.82.10",
+	"version": "0.82.11",
 	"license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.105.0"

--- a/src/services/cyberbrickOtaProvisioningService.ts
+++ b/src/services/cyberbrickOtaProvisioningService.ts
@@ -51,6 +51,7 @@ export class CyberBrickOtaProvisioningService {
 		private readonly uploader: Pick<
 			MicropythonUploader,
 			| 'listPorts'
+			| 'ensureMpremoteAvailable'
 			| 'readCyberBrickDeviceId'
 			| 'writeCyberBrickDeviceId'
 			| 'scanCyberBrickWifi'
@@ -65,6 +66,11 @@ export class CyberBrickOtaProvisioningService {
 	}
 
 	async listUsbPorts(): Promise<CyberBrickUsbPortList> {
+		const mpremoteReady = await this.uploader.ensureMpremoteAvailable();
+		if (!mpremoteReady.success) {
+			throw createCyberBrickUploadError('mpremote-unavailable', mpremoteReady.message, { details: mpremoteReady.details });
+		}
+
 		const result = await this.uploader.listPorts('cyberbrick');
 		return {
 			ports: result.ports.map(port => this.toPortSummary(port)),

--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -88,6 +88,10 @@ export interface UploadRequest {
  */
 export type ProgressCallback = (progress: UploadProgress) => void;
 
+export type MpremoteAvailabilityResult =
+	| { success: true }
+	| { success: false; stage: UploadStage; message: string; details?: string };
+
 /**
  * 指令執行介面（用於依賴注入）
  */
@@ -277,6 +281,46 @@ export class MicropythonUploader {
 			log('[blockly] mpremote 安裝失敗', 'error', error);
 			return false;
 		}
+	}
+
+	async ensureMpremoteAvailable(onProgress?: ProgressCallback): Promise<MpremoteAvailabilityResult> {
+		onProgress?.({
+			stage: 'checking_tool',
+			progress: 10,
+			message: 'Checking mpremote tool...',
+		});
+
+		const hasPython = await this.checkPythonEnvironment();
+		if (!hasPython) {
+			return {
+				success: false,
+				stage: 'checking_tool',
+				message: 'PlatformIO Python environment not found. Please install PlatformIO first.',
+			};
+		}
+
+		const hasMpremote = await this.checkMpremoteInstalled();
+		if (hasMpremote) {
+			return { success: true };
+		}
+
+		onProgress?.({
+			stage: 'installing_tool',
+			progress: 20,
+			message: 'Installing mpremote...',
+		});
+
+		const installed = await this.installMpremote(onProgress);
+		if (!installed) {
+			return {
+				success: false,
+				stage: 'installing_tool',
+				message: 'mpremote installation failed',
+				details: 'Please run manually: pip install mpremote',
+			};
+		}
+
+		return { success: true };
 	}
 
 	/**
@@ -1020,42 +1064,15 @@ print(json.dumps(result))
 			return this.createFailureResult(startTime, port || 'unknown', 'preparing', 'Code cannot be empty');
 		}
 
-		// 階段 2: 檢查工具
-		onProgress?.({
-			stage: 'checking_tool',
-			progress: 10,
-			message: 'Checking mpremote tool...',
-		});
-
-		const hasPython = await this.checkPythonEnvironment();
-		if (!hasPython) {
+		const mpremoteReady = await this.ensureMpremoteAvailable(onProgress);
+		if (!mpremoteReady.success) {
 			return this.createFailureResult(
 				startTime,
 				port || 'unknown',
-				'checking_tool',
-				'PlatformIO Python environment not found. Please install PlatformIO first.'
+				mpremoteReady.stage,
+				mpremoteReady.message,
+				mpremoteReady.details
 			);
-		}
-
-		const hasMpremote = await this.checkMpremoteInstalled();
-		if (!hasMpremote) {
-			// 階段 3: 安裝工具
-			onProgress?.({
-				stage: 'installing_tool',
-				progress: 20,
-				message: 'Installing mpremote...',
-			});
-
-			const installed = await this.installMpremote(onProgress);
-			if (!installed) {
-				return this.createFailureResult(
-					startTime,
-					port || 'unknown',
-					'installing_tool',
-					'mpremote installation failed',
-					'Please run manually: pip install mpremote'
-				);
-			}
 		}
 
 		// 階段 4: 連接裝置

--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -283,6 +283,13 @@ export class MicropythonUploader {
 		}
 	}
 
+	/**
+	 * 確認 PlatformIO Python 環境可用，並在需要時透過同一個 penv 安裝 mpremote。
+	 *
+	 * 成功時只代表 mpremote 已可被呼叫，不會執行連接埠偵測或裝置通訊。
+	 * 失敗時回傳可直接呈現在上傳結果中的 stage/message/details。
+	 * 若提供 onProgress，會回報 checking_tool 與 installing_tool 階段；呼叫端應避免和後續 upload() 進度重複顯示。
+	 */
 	async ensureMpremoteAvailable(onProgress?: ProgressCallback): Promise<MpremoteAvailabilityResult> {
 		onProgress?.({
 			stage: 'checking_tool',

--- a/src/test/services/cyberbrickOtaProvisioningService.test.ts
+++ b/src/test/services/cyberbrickOtaProvisioningService.test.ts
@@ -27,6 +27,7 @@ suite('CyberBrickOtaProvisioningService', () => {
 			now: () => new Date('2026-01-20T12:00:00.000Z'),
 		});
 		uploader = {
+			ensureMpremoteAvailable: sinon.stub().resolves({ success: true }),
 			listPorts: sinon.stub().resolves({ ports: [] }),
 			readCyberBrickDeviceId: sinon.stub().resolves(CYBERBRICK_TEST_DEVICE_ID),
 			writeCyberBrickDeviceId: sinon.stub().resolves(),
@@ -51,6 +52,7 @@ suite('CyberBrickOtaProvisioningService', () => {
 		assert.strictEqual(ports.ports.length, 2);
 		assert.strictEqual(ports.ports[0].path, '/dev/cu.usbmodem1');
 		assert.strictEqual(ports.autoDetected, undefined);
+		assert.strictEqual(uploader.ensureMpremoteAvailable.calledOnce, true);
 	});
 
 	test('returns auto-detected CyberBrick USB port for settings dropdown preselection', async () => {
@@ -64,6 +66,28 @@ suite('CyberBrickOtaProvisioningService', () => {
 
 		assert.strictEqual(result.autoDetected, '/dev/cu.usbmodem1');
 		assert.strictEqual(result.ports[0].displayName.includes('/dev/cu.usbmodem1'), true);
+	});
+
+	test('reports mpremote setup failures before listing CyberBrick USB ports', async () => {
+		uploader.ensureMpremoteAvailable.resolves({
+			success: false,
+			stage: 'installing_tool',
+			message: 'mpremote installation failed',
+			details: 'Please run manually: pip install mpremote',
+		});
+		const service = new CyberBrickOtaProvisioningService(settingsService, uploader);
+
+		await assert.rejects(
+			() => service.listUsbPorts(),
+			error => {
+				const candidate = error as { code?: string; message?: string; details?: string };
+				assert.strictEqual(candidate.code, 'mpremote-unavailable');
+				assert.strictEqual(candidate.message, 'mpremote installation failed');
+				assert.strictEqual(candidate.details, 'Please run manually: pip install mpremote');
+				return true;
+			}
+		);
+		assert.strictEqual(uploader.listPorts.called, false);
 	});
 
 	test('returns device-side Wi-Fi scan results and supports empty lists', async () => {

--- a/src/test/suite/messageHandler.test.ts
+++ b/src/test/suite/messageHandler.test.ts
@@ -159,6 +159,7 @@ suite('MessageHandler – generic requestUpload OTA fallback', () => {
 			nextActions: [],
 		});
 
+		sandbox.stub(MicropythonUploader.prototype, 'ensureMpremoteAvailable').resolves({ success: true });
 		sandbox.stub(MicropythonUploader.prototype, 'listPorts').resolves({ ports: [], autoDetected: undefined });
 
 		(handler as any).cyberBrickOtaUploader = {
@@ -199,5 +200,62 @@ suite('MessageHandler – generic requestUpload OTA fallback', () => {
 		assert.ok(panelRefresh, 'generic OTA fallback should refresh CyberBrick panel state after upload');
 		assert.strictEqual(panelRefresh.payload.settings.pairedDevices[0].agentVersion, CYBERBRICK_OTA_AGENT_TARGET_VERSION);
 			assert.ok((handler as any).cyberBrickOtaUploader.checkReadiness.calledOnce, 'generic OTA fallback should refresh panel state from live readiness');
+	});
+
+	test('requestUpload prepares mpremote before CyberBrick USB pre-detect', async () => {
+		const { handler, webviewPostMessage } = makeHandlerHarness(sandbox, vscodeMock);
+		const ensureMpremote = sandbox.stub(MicropythonUploader.prototype, 'ensureMpremoteAvailable').callsFake(async onProgress => {
+			onProgress?.({ stage: 'installing_tool', progress: 20, message: 'Installing mpremote...' });
+			return { success: true };
+		});
+		const listPorts = sandbox.stub(MicropythonUploader.prototype, 'listPorts').resolves({
+			ports: [{ path: 'COM7', vendorId: '303A', productId: '1001' }],
+			autoDetected: 'COM7',
+		});
+		const upload = sandbox.stub(MicropythonUploader.prototype, 'upload').resolves({
+			success: true,
+			timestamp: '2026-06-04T00:00:00.000Z',
+			port: 'COM7',
+			duration: 1,
+		});
+
+		await handler.handleMessage({
+			command: 'requestUpload',
+			board: 'cyberbrick',
+			code: 'print(1)',
+		});
+
+		sinon.assert.callOrder(ensureMpremote, listPorts, upload);
+		assert.deepStrictEqual(upload.firstCall.args[0], { code: 'print(1)', board: 'cyberbrick', port: 'COM7' });
+		const messages = webviewPostMessage.getCalls().map((call: sinon.SinonSpyCall) => call.args[0]);
+		assert.ok(messages.some((message: { command?: string; stage?: string }) => message.command === 'uploadProgress' && message.stage === 'installing_tool'));
+		assert.ok(messages.some((message: { command?: string; success?: boolean; port?: string }) => message.command === 'uploadResult' && message.success === true && message.port === 'COM7'));
+	});
+
+	test('requestUpload reports mpremote setup failure before falling back to OTA', async () => {
+		const { handler, webviewPostMessage } = makeHandlerHarness(sandbox, vscodeMock);
+		sandbox.stub(MicropythonUploader.prototype, 'ensureMpremoteAvailable').resolves({
+			success: false,
+			stage: 'installing_tool',
+			message: 'mpremote installation failed',
+			details: 'Please run manually: pip install mpremote',
+		});
+		const listPorts = sandbox.stub(MicropythonUploader.prototype, 'listPorts').resolves({ ports: [], autoDetected: undefined });
+		const otaUpload = sandbox.stub().resolves({ status: 'succeeded' });
+		(handler as any).cyberBrickOtaUploader = { upload: otaUpload };
+
+		await handler.handleMessage({
+			command: 'requestUpload',
+			board: 'cyberbrick',
+			code: 'print(1)',
+		});
+
+		assert.strictEqual(listPorts.called, false);
+		assert.strictEqual(otaUpload.called, false);
+		const result = webviewPostMessage.getCalls().map((call: sinon.SinonSpyCall) => call.args[0]).find((message: { command?: string }) => message.command === 'uploadResult');
+		assert.strictEqual(result.success, false);
+		assert.strictEqual(result.error.stage, 'installing_tool');
+		assert.strictEqual(result.error.message, 'mpremote installation failed');
+		assert.strictEqual(result.error.details, 'Please run manually: pip install mpremote');
 	});
 });

--- a/src/webview/messageHandler.ts
+++ b/src/webview/messageHandler.ts
@@ -1976,12 +1976,6 @@ export class WebViewMessageHandler {
 					return;
 				}
 
-				this.sendUploadProgress({
-					stage: 'connecting',
-					progress: 40,
-					message: 'Detecting CyberBrick...',
-				});
-
 				const { autoDetected } = await uploader.listPorts('cyberbrick');
 				usbPort = autoDetected;
 			}

--- a/src/webview/messageHandler.ts
+++ b/src/webview/messageHandler.ts
@@ -1958,6 +1958,30 @@ export class WebViewMessageHandler {
 			// 先偵測 USB 連線（若已明確指定 port 則直接使用）
 			let usbPort: string | undefined = message.port;
 			if (!usbPort) {
+				const mpremoteReady = await uploader.ensureMpremoteAvailable((progress: UploadProgress) => {
+					this.sendUploadProgress(progress);
+				});
+				if (!mpremoteReady.success) {
+					this.sendUploadResult({
+						success: false,
+						timestamp: new Date().toISOString(),
+						port: 'unknown',
+						duration: 0,
+						error: {
+							stage: mpremoteReady.stage,
+							message: mpremoteReady.message,
+							details: mpremoteReady.details,
+						},
+					});
+					return;
+				}
+
+				this.sendUploadProgress({
+					stage: 'connecting',
+					progress: 40,
+					message: 'Detecting CyberBrick...',
+				});
+
 				const { autoDetected } = await uploader.listPorts('cyberbrick');
 				usbPort = autoDetected;
 			}


### PR DESCRIPTION
## 變更摘要 Summary

修復 CyberBrick 在新 Windows 環境尚未安裝 `mpremote` 時，USB port 預掃描會先失敗並被誤判成找不到 COM port 的問題。這次把既有 PlatformIO `penv` 的 `mpremote` 自動安裝流程抽成共用方法，讓 USB 上傳 pre-detect 與 OTA 設定頁 USB port 清單都先確認 `mpremote` 可用。

## Review Boundary

請特別注意：這個 PR **沒有**改動 v0.82.10 已在 Windows/macOS 手動驗證過的 `mpremote ... fs cp` argv 分流，也沒有改動 Windows `resume + run` helper 的 shell 相容路徑。此次變更只處理「列 port / pre-detect 前先準備 mpremote」的時機問題，避免 reviewer 誤判成需要重新調整 Windows command execution strategy。

## 相關 Spec Related Spec

- N/A：回歸修復與測試版驗證修正

## 變更類型 Type of Change

- [x] 🐛 Bug 修復 (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 (non-breaking change which adds functionality)
- [ ] 💥 破壞性變更 (fix or feature that would cause existing functionality to change)
- [x] 📝 文件更新 (documentation only changes)

## 變更內容 Changes

- 新增 `MicropythonUploader.ensureMpremoteAvailable()`，沿用既有 PlatformIO `penv` Python / pip / `mpremote` 安裝流程。
- CyberBrick USB 上傳在未指定 port 時，先準備 `mpremote`，再執行 `listPorts('cyberbrick')`。
- OTA 設定頁 USB port 清單在列 port 前同樣先準備 `mpremote`；失敗時回報明確的 `mpremote-unavailable`，不再靜默顯示空清單。
- 補上 regression tests，鎖住 `ensureMpremoteAvailable -> listPorts -> upload` 的順序，以及安裝失敗時不得 fallback 到 OTA。
- 版本更新至 `0.82.11`，並更新 CHANGELOG / SECURITY 註記。

## 測試計劃 Test Plan

- [x] `git diff --check`
- [x] `npm audit --audit-level=low`：0 vulnerabilities
- [x] `npm run lint`
- [x] `npm run compile-tests`
- [x] `npm test`：897 passing, 1 pending
- [x] VSIX package verification：`singular-blockly@0.82.11`
- [x] 手動測試：2 台 Windows + 1 台 macOS，CyberBrick USB 上傳 / Wi-Fi 掃描 / OTA 設定頁 port 偵測通過

## 測試版 VSIX

- `singular-blockly-0.82.11-mpremote-autoinstall-test.vsix`
- SHA256: `a8903e0843dafbd7557b96fc3e1f8bc5cb5943b09605bac02204662f5387c9cd`
