### PR TITLE
fix(manifest): make PlatformIO an optional runtime requirement (VSCodium / Open VSX support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,11 @@ code --install-extension singular-blockly-X.Y.Z.vsix
 
 ## Requirements
 
-- Visual Studio Code 1.105.0 or higher
+- Visual Studio Code 1.105.0 or higher, or a compatible build such as VSCodium
 - Node.js 22.16.0 or higher
 - Basic understanding of visual programming and your target board workflow
 - **For Arduino / ESP32 boards:**
-    - PlatformIO IDE Extension
+    - PlatformIO IDE Extension, installed separately (a compatible fork such as `pioarduino.pioarduino-ide` also works)
     - C/C++ Extension (`ms-vscode.cpptools`)
 - **For CyberBrick (MicroPython):**
     - Python 3.x installed

--- a/package.json
+++ b/package.json
@@ -283,9 +283,6 @@
 		"node-ssh": "^13.2.1",
 		"zod": "^4.1.13"
 	},
-	"extensionDependencies": [
-		"platformio.platformio-ide"
-	],
 	"overrides": {
 		"hono": "^4.12.25",
 		"@hono/node-server": "^1.19.13",

--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -302,7 +302,9 @@ export class MicropythonUploader {
 			return {
 				success: false,
 				stage: 'checking_tool',
-				message: 'PlatformIO Python environment not found. Please install PlatformIO first.',
+				message: 'PlatformIO Python environment (~/.platformio/penv) not found.',
+				details:
+					'CyberBrick upload reuses the PlatformIO Python environment. Install the PlatformIO IDE extension — or the pioarduino fork (pioarduino.pioarduino-ide), which is available on Open VSX for VSCodium — then run a build once so the environment (penv) is initialized.',
 			};
 		}
 

--- a/src/services/settingsManager.ts
+++ b/src/services/settingsManager.ts
@@ -49,6 +49,14 @@ export class SettingsManager {
 	private readonly DEFAULT_AUTO_BACKUP_INTERVAL = 30; // 預設 30 分鐘
 
 	/**
+	 * 偵測是否已安裝 PlatformIO provider 擴充功能（官方 platformio.platformio-ide
+	 * 或相容分支 pioarduino.pioarduino-ide）。以欄位形式提供，方便測試覆寫。
+	 */
+	private platformIOProviderDetector: () => boolean = () =>
+		vscode.extensions.getExtension('platformio.platformio-ide') !== undefined ||
+		vscode.extensions.getExtension('pioarduino.pioarduino-ide') !== undefined;
+
+	/**
 	 * 建立設定管理器實例
 	 * @param workspacePath 工作區路徑
 	 * @param fileService 可選的檔案服務實例（主要用於測試）
@@ -121,9 +129,14 @@ export class SettingsManager {
 			// 讀取現有設定
 			const settings = await this.fileService.readJsonFile<Record<string, any>>(this.settingsPath, {});
 
-			// 更新 PlatformIO 相關設定
-			settings['platformio-ide.autoOpenPlatformIOIniFile'] = false;
-			settings['platformio-ide.disablePIOHomeStartup'] = true;
+			// 僅在偵測到 PlatformIO provider（官方擴充功能或 pioarduino 分支）時才寫入
+			// platformio-ide 設定，避免在未安裝任何 provider 時污染專案的 .vscode/settings.json
+			if (this.platformIOProviderDetector()) {
+				settings['platformio-ide.autoOpenPlatformIOIniFile'] = false;
+				settings['platformio-ide.disablePIOHomeStartup'] = true;
+			} else {
+				log('No PlatformIO provider detected (platformio.platformio-ide / pioarduino.pioarduino-ide); skipping platformio-ide settings', 'info');
+			}
 
 			// 確保 Singular Blockly 主題設定存在
 			if (!settings['singular-blockly.theme']) {

--- a/src/test/settingsManager.test.ts
+++ b/src/test/settingsManager.test.ts
@@ -75,10 +75,14 @@ describe('Settings Manager', () => {
 		assert.strictEqual(updatedSettings['test.setting'], 'new-value');
 	});
 
-	it('should configure PlatformIO settings', async () => {
+	it('should configure PlatformIO settings when a provider is installed', async () => {
 		// 設定一個現有的設定檔
 		const existingSettings = { 'existing.setting': 'value' };
 		fsMock.addFile(settingsPath, JSON.stringify(existingSettings));
+
+		// 模擬已安裝 PlatformIO provider（官方擴充功能或 pioarduino 分支）
+		// @ts-ignore - 覆寫私有偵測器以進行測試
+		settingsManager.platformIOProviderDetector = () => true;
 
 		// 測試設定 PlatformIO
 		await settingsManager.configurePlatformIOSettings();
@@ -90,6 +94,28 @@ describe('Settings Manager', () => {
 		assert.strictEqual(updatedSettings['existing.setting'], 'value');
 		assert.strictEqual(updatedSettings['platformio-ide.autoOpenPlatformIOIniFile'], false);
 		assert.strictEqual(updatedSettings['platformio-ide.disablePIOHomeStartup'], true);
+		assert.strictEqual(updatedSettings['singular-blockly.theme'], 'light');
+	});
+
+	it('should not write platformio-ide settings when no provider is installed', async () => {
+		// 設定一個現有的設定檔
+		const existingSettings = { 'existing.setting': 'value' };
+		fsMock.addFile(settingsPath, JSON.stringify(existingSettings));
+
+		// 模擬未安裝任何 PlatformIO provider
+		// @ts-ignore - 覆寫私有偵測器以進行測試
+		settingsManager.platformIOProviderDetector = () => false;
+
+		// 測試設定 PlatformIO
+		await settingsManager.configurePlatformIOSettings();
+
+		// 驗證未污染 platformio-ide 設定，但仍保留主題預設值
+		const updatedContent = fsMock.files.get(settingsPath);
+		assert.ok(updatedContent);
+		const updatedSettings = JSON.parse(updatedContent);
+		assert.strictEqual(updatedSettings['existing.setting'], 'value');
+		assert.strictEqual(updatedSettings['platformio-ide.autoOpenPlatformIOIniFile'], undefined);
+		assert.strictEqual(updatedSettings['platformio-ide.disablePIOHomeStartup'], undefined);
 		assert.strictEqual(updatedSettings['singular-blockly.theme'], 'light');
 	});
 


### PR DESCRIPTION
## Summary

Removes the hard `extensionDependencies` on `platformio.platformio-ide` so Singular Blockly can install and activate on **VSCodium / Open VSX** and work with maintained PlatformIO forks such as `pioarduino.pioarduino-ide`.

Currently the manifest declares:

```json
"extensionDependencies": ["platformio.platformio-ide"]
```

VS Code / VSCodium treat this as a **hard** requirement: if that exact extension id is not installed, the editor silently refuses to activate Singular Blockly. This excludes two legitimate, otherwise-compatible setups:

1. **VSCodium / Open VSX users** — the official `platformio.platformio-ide` is not reliably available there.
2. **Users of the maintained `pioarduino.pioarduino-ide` fork** — a drop-in PlatformIO replacement that many people now run on recent VS Code builds.

## Why this is safe

The extension never resolves PlatformIO by extension id. It only:

- edits / deletes `platformio.ini`, and
- reads the `platformio-ide` **settings namespace** (`platformioDiagnosticService.ts`), which both the official extension and its forks provide.

PlatformIO availability is already surfaced at runtime via the PlatformIO diagnostic service (`singular-blockly.checkPlatformioStatus`), so the hard manifest dependency was redundant — it only added a blocker. PlatformIO remains a documented runtime requirement; it just isn't force-installed via the manifest.

## Changes

- `package.json`: remove the `extensionDependencies` block.
- `README.md`: note VSCodium compatibility and that PlatformIO (or a compatible fork) must be installed separately.

## Verified

Reproduced on VSCodium 1.121 with `pioarduino.pioarduino-ide` 1.4.4 installed: with the original manifest the extension never appears in the activation log; after dropping the dependency it activates and the Blockly editor, code generation, and `platformio.ini` handling work normally. Copilot-only features (`vscode.lm` AI suggestions, MCP provider) stay dormant by their existing runtime guards, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)