### PR TITLE
fix(services): normalize CRLF line endings in parsePortList (closes #94)

### DIFF
--- a/src/services/micropythonUploader.ts
+++ b/src/services/micropythonUploader.ts
@@ -830,7 +830,7 @@ print(json.dumps(result))
 	 */
 	private parsePortList(output: string): ComPortInfo[] {
 		const ports: ComPortInfo[] = [];
-		const lines = output.trim().split('\n');
+		const lines = output.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
 
 		for (const line of lines) {
 			// 格式：COM10 58:E6:C5:A7:76:54 303a:1001 Microsoft None

--- a/src/test/services/micropythonUploaderCyberBrickHelpers.test.ts
+++ b/src/test/services/micropythonUploaderCyberBrickHelpers.test.ts
@@ -628,4 +628,39 @@ suite('MicropythonUploader CyberBrick helper commands', () => {
 		assert.ok(uploadedCode.includes('_singular_blockly_ota_agent.start_background(False)'), 'should inject OTA bootstrap as conservative fallback when check fails');
 		assert.ok(uploadedCode.includes('print("student")'), 'should preserve user code');
 	});
+
+	test('parsePortList correctly parses Windows CRLF output when CyberBrick is not the last line', () => {
+		const uploader = createUploader({ exec: async () => ({ stdout: '', stderr: '' }) });
+		const parsePortList = (uploader as unknown as { parsePortList(output: string): unknown[] }).parsePortList.bind(uploader);
+
+		// Simulate mpremote output on Windows with CRLF line endings; CyberBrick device is in the middle
+		const windowsOutput =
+			'COM3 None 0000:0000 Microsoft None\r\n' +
+			'COM4 None 0000:0000 Microsoft None\r\n' +
+			'COM9 58:E6:C5:A7:76:54 303a:1001 Microsoft None\r\n' +
+			'COM14 None 0000:0000 Microsoft None\r\n' +
+			'COM15 None 0000:0000 Microsoft None\r\n';
+
+		const ports = parsePortList(windowsOutput) as Array<{ path: string; vendorId: string; productId: string }>;
+		const cyberbrick = ports.find(p => p.vendorId === '303A' && p.productId === '1001');
+
+		assert.ok(cyberbrick, 'CyberBrick device should be detected even when it is not the last line in CRLF output');
+		assert.strictEqual(cyberbrick.path, 'COM9');
+	});
+
+	test('parsePortList correctly parses LF-only output (non-Windows)', () => {
+		const uploader = createUploader({ exec: async () => ({ stdout: '', stderr: '' }) });
+		const parsePortList = (uploader as unknown as { parsePortList(output: string): unknown[] }).parsePortList.bind(uploader);
+
+		const lfOutput =
+			'/dev/ttyUSB0 None 0000:0000 None None\n' +
+			'/dev/ttyACM0 58:E6:C5:A7:76:54 303a:1001 CyberBrick None\n' +
+			'/dev/ttyUSB1 None 0000:0000 None None\n';
+
+		const ports = parsePortList(lfOutput) as Array<{ path: string; vendorId: string; productId: string }>;
+		const cyberbrick = ports.find(p => p.vendorId === '303A' && p.productId === '1001');
+
+		assert.ok(cyberbrick, 'CyberBrick device should be detected from LF-only output');
+		assert.strictEqual(cyberbrick.path, '/dev/ttyACM0');
+	});
 });


### PR DESCRIPTION
## 🐛 Bug 修復 Bug Fix

**問題描述**: Windows 上 CyberBrick USB 裝置偵測失敗，即使 Device Manager 和 mpremote 均可見裝置
**Issue**: #94
**影響版本**: v0.82.17

---

## 問題分析 Problem Analysis

### 問題現象 Symptoms

Windows 的 `mpremote connect list` 輸出使用 CRLF 行尾（`\r\n`）。`parsePortList()` 只以 `\n` 分割，導致中間行殘留 `\r`，port regex 末端的 `\s+(.*)$` 無法消化 `\r`，結果回傳空陣列。CyberBrick 排在最後一行時不受影響（因 `output.trim()` 已去除末端空白），但只要有任何其他 COM port 排在其後即告失敗。

### 根本原因 Root Cause

```diff
- const lines = output.trim().split('\n');
+ const lines = output.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
```

`split('\n')` 不處理 Windows CRLF，需改用 `/\r?\n/` 並對每行 trim。

### 影響範圍 Impact

- [x] 高 - 功能完全無法使用（Windows 使用者無法偵測到 CyberBrick USB 裝置）

---

## 修復方案 Solution

### 變更摘要 Changes Summary

在 `parsePortList()` 將行分割改為跨平台正規化：以 `/\r?\n/` 分割後，對每行執行 `trim()` 並過濾空行，確保 Windows CRLF 與 Linux/macOS LF 輸出均可正確解析。

### 修改檔案 Modified Files

| 檔案路徑 | 變更說明 |
| -------- | -------- |
| `src/services/micropythonUploader.ts` | `parsePortList()` 改用 `split(/\r?\n/)` + `map(trim)` + `filter(Boolean)` |
| `src/test/services/micropythonUploaderCyberBrickHelpers.test.ts` | 新增 Windows CRLF 及 Linux LF 兩個回歸測試 |

---

## 測試計劃 Test Plan

### 重現步驟 Steps to Reproduce (Before Fix)

1. Windows 10，連接 CyberBrick（VID 303A, PID 1001）
2. 確認 Device Manager 顯示裝置（例如 COM9）
3. 開啟 Singular Blockly CyberBrick USB port 清單
4. 觀察到空清單（裝置未出現）

### 驗證步驟 Verification Steps (After Fix)

1. 安裝修復後的 VSIX
2. 連接 CyberBrick（確保不是 `mpremote connect list` 輸出的最後一行）
3. CyberBrick 應正確出現在 port 清單並被自動選取

### 自動化測試 Automated Tests

- [x] `npm run lint` 通過
- [x] `npm run compile` 成功
- [x] `npm run test` 通過（含新增的兩個 CRLF 回歸測試）
- [x] 已新增回歸測試

---

## 回歸風險 Regression Risk

- [x] 低 - 變更範圍小，不影響其他功能

`filter(Boolean)` 過濾空行的行為與原本 `output.trim()` 等效，在非 Windows 環境下結果完全相同。

---

## 檢查清單 Checklist

- [x] Bug 已確認修復（Windows 跨裝置測試通過）
- [x] 回歸測試已新增
- [x] 變更符合最小化原則（1 行 fix + 2 個測試）