### PR TITLE
docs(readme): 補充 VSCodium 與 Open VSX 安裝說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,14 @@ code --install-extension singular-blockly-X.Y.Z.vsix
 
 ## Requirements
 
-- Visual Studio Code 1.105.0 or higher
+- Visual Studio Code 1.105.0 or higher, or a compatible Open VSX-based editor such as VSCodium
 - Node.js 22.16.0 or higher
 - Basic understanding of visual programming and your target board workflow
+- **PlatformIO environment provider (required for all boards):**
+    - Singular Blockly automatically starts installation when the Blockly editor is first opened.
+    - VS Code uses `platformio.platformio-ide`; Open VSX environments such as VSCodium automatically fall back to `pioarduino.pioarduino-ide`.
+    - If neither provider can be installed automatically, follow the prompt in the Extensions panel.
 - **For Arduino / ESP32 boards:**
-    - PlatformIO IDE Extension
     - C/C++ Extension (`ms-vscode.cpptools`)
 - **For CyberBrick (MicroPython):**
     - Python 3.x installed


### PR DESCRIPTION
## 變更摘要 Summary

補充 VSCodium 與 Open VSX 的公開安裝需求，讓 README 與 v0.83.0 已發布的 provider 自動安裝流程一致。

## 變更內容 Changes

- 說明 VSCodium 等 Open VSX 編輯器受到支援
- 說明所有板子共用 PlatformIO environment provider 前置需求
- 記錄 VS Code 使用 PlatformIO IDE、Open VSX 自動 fallback 至 pioarduino
- 說明自動安裝失敗時可透過 Extensions 面板處理

## 變更類型 Type of Change

- [x] 文件更新

## 驗證 Validation

- [x] `git diff --check`
- [x] 確認僅修改 `README.md`，不影響執行期程式碼

Related: #91, #93
