### PR TITLE
fix(webview): 修正 PlatformIO 安裝後初始化流程

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [未發布] Unreleased
 
+### 🐛 修復 Bug Fixes
+
+- PlatformIO IDE 或 pioarduino provider 自動安裝成功後，現在會先開啟 PlatformIO Home 觸發 Core 初始化，再保留既有重新載入提示；Home 命令失敗不會誤觸另一個 provider 安裝，安裝期間重複開啟積木編輯器也不會產生重複流程
+  After successfully installing the PlatformIO IDE or pioarduino provider, Singular Blockly now opens PlatformIO Home to trigger Core initialization before retaining the existing reload prompt; Home command failures no longer trigger another provider installation, and reopening the Blockly editor during setup no longer starts duplicate flows
+
 ## [0.84.0] - 2026-08-04
 
 ### ✨ 新增功能 Features

--- a/specs/063-vscodium-openvsx-guided-install/contracts/vs-code-api.md
+++ b/specs/063-vscodium-openvsx-guided-install/contracts/vs-code-api.md
@@ -37,7 +37,7 @@ await vscode.commands.executeCommand(
 
 **回傳**：`Thenable<void>`（Promise）
 
-**成功**：安裝完成後由 Singular Blockly 顯示「Reload Now」提示。
+**成功**：安裝完成後由 Singular Blockly 呼叫 `platformio-ide.showHome` 啟動 provider／Core 初始化，再顯示「Reload Now」提示。
 
 **失敗情境**：
 - Extension ID 在當前 marketplace 不存在 → **rejected Promise**（實作時需以單元測試確認錯誤型別）
@@ -80,6 +80,28 @@ await vscode.commands.executeCommand('workbench.extensions.search', 'platformio'
 
 ---
 
+## `platformio-ide.showHome`
+
+**用途**：provider 安裝成功後開啟 PlatformIO Home，並透過 contributed command 啟動 PlatformIO IDE 或 pioarduino extension，使其進入 Core 初始化流程。
+
+```typescript
+try {
+  await executeCommand('platformio-ide.showHome');
+} catch {
+  log('[PenvProviderService] Failed to open PlatformIO Home; continuing with reload prompt', 'warn');
+}
+```
+
+**呼叫時機**：僅限本次 `installExtension` 剛回傳成功；若積木編輯器開啟時 provider 已存在，不自動開啟 Home。
+
+**並行約束**：同一個 `WebViewManager` 在 provider setup settle 前保存 in-flight Promise；重複開啟積木編輯器不得再次呼叫安裝、Home 或 reload。settle 後清除狀態，下一次操作重新執行 provider 偵測。
+
+**跨 provider 行為**：`platformio.platformio-ide` 與 `pioarduino.pioarduino-ide` 共用相同命令 ID，不需要依 provider 分支命令。
+
+**失敗處理**：Home rejected 不改變已成功的 provider 安裝結果、不觸發另一個 provider fallback，也不記錄第三方例外內容；流程繼續顯示既有 reload 提示。
+
+---
+
 ## `vscode.window.showInformationMessage`
 
 **用途**：只顯示安裝失敗說明或安裝成功後的重新載入提示；不作為安裝前確認。
@@ -91,14 +113,14 @@ if (selected === reloadButton) {
 }
 ```
 
-**行為**：provider 缺失時直接執行 `installExtension`，不先顯示自訂確認按鈕。兩個 provider 都失敗時則顯示不含按鈕的手動安裝說明。
+**行為**：provider 缺失時直接執行 `installExtension`，不先顯示自訂確認按鈕。安裝成功時等待 Home 命令完成或失敗隔離後才顯示 reload；兩個 provider 都失敗時則顯示不含按鈕的手動安裝說明。
 
 ---
 
 ## 重新載入處理
 
-只有安裝指令成功後，擴充功能才顯示「Reload Now」提示並可呼叫 `workbench.action.reloadWindow`。兩個 provider 均失敗時不得進入此路徑。
+只有安裝指令成功後，擴充功能才呼叫 PlatformIO Home 並顯示「Reload Now」提示；使用者選擇後可呼叫 `workbench.action.reloadWindow`。兩個 provider 均失敗時不得進入 Home 或 reload 路徑。
 
-重新載入後 PlatformIO IDE / pioarduino 啟動，自動執行 `get-platformio.py` 建立 `~/.platformio/penv/`，無需使用者手動操作。
+Home 命令會啟動 PlatformIO IDE / pioarduino 並進入其 Core installer；重新載入提示仍作為後續完成設定的保底，無需使用者手動執行 build。
 
 重新載入提示只代表 provider 已安裝，**不代表 PlatformIO Core 已可用**。Core 狀態由實際 `--version` 探測決定。

--- a/specs/063-vscodium-openvsx-guided-install/data-model.md
+++ b/specs/063-vscodium-openvsx-guided-install/data-model.md
@@ -50,9 +50,14 @@ ProviderInstallResult
 ```
 偵測 provider extension
   ├── 未安裝
-  │     └── 直接啟動 provider 安裝
-  │           ├── 安裝成功 → 顯示 reload（只代表 provider 已安裝）
-  │           └── 安裝失敗 → [manual-required] → 開啟 Extensions 面板
+  │     └── 檢查 provider setup 狀態
+  │           ├── in-flight → 共用既有流程，不重複副作用
+  │           └── idle → 建立 setup Promise 並啟動 provider 安裝
+  │                 ├── 安裝成功 → await `platformio-ide.showHome`
+  │                 │                 ├── 成功 → 顯示 reload
+  │                 │                 └── 失敗 → 記錄警告 → 顯示 reload
+  │                 └── 安裝失敗 → [manual-required] → 開啟 Extensions 面板
+  │                       （setup settle 後回到 idle，允許下次重試）
   │
   └── 已安裝
         └── 實際執行所有可信候選的 `--version`

--- a/specs/063-vscodium-openvsx-guided-install/plan.md
+++ b/specs/063-vscodium-openvsx-guided-install/plan.md
@@ -4,7 +4,7 @@
 
 ## 摘要
 
-從 `package.json` 移除硬性 `extensionDependencies`，使擴充功能可在 VSCodium / Open VSX 環境啟動。新增集中化的 `PenvProviderService`，統一管理 provider 偵測與安裝 fallback（platformio → pioarduino → 手動搜尋），並在所有板子開啟積木編輯器時維持舊版共同前置環境。另以 `PlatformioInvocationResolver` 驗證實際可執行的 Core 啟動方式，支援 `PLATFORMIO_CORE_DIR` 與 `python -m platformio` fallback。
+從 `package.json` 移除硬性 `extensionDependencies`，使擴充功能可在 VSCodium / Open VSX 環境啟動。新增集中化的 `PenvProviderService`，統一管理 provider 偵測與安裝 fallback（platformio → pioarduino → 手動搜尋），並在所有板子開啟積木編輯器時維持舊版共同前置環境。任一 provider 安裝成功後會呼叫固定命令 `platformio-ide.showHome`，立即啟動 provider 與 Core 初始化，再保留既有重新載入提示。另以 `PlatformioInvocationResolver` 驗證實際可執行的 Core 啟動方式，支援 `PLATFORMIO_CORE_DIR` 與 `python -m platformio` fallback。
 
 ## 技術背景
 
@@ -32,7 +32,7 @@
 |------|------|------|
 | I — 簡潔可維護 | `PenvProviderService` 職責單一；重試邏輯封裝於服務層 | ✅ |
 | II — 模組化 | 新服務集中管理，避免在多個 uploader 重複實作通知邏輯 | ✅ |
-| III — 避免過度開發 | 僅實作規格所需功能；無前置確認步驟或 post-install wizard，安裝成功後只提供必要的 reload 按鈕 | ✅ |
+| III — 避免過度開發 | 僅實作規格所需功能；無前置確認步驟或自訂 wizard，安裝成功後只呼叫 provider 既有 Home 命令並保留 reload 按鈕 | ✅ |
 | VI — 結構化日誌 | 所有新偵測邏輯使用 `log()` 記錄，不使用 `console.log` | ✅ |
 | VII — 測試覆蓋率 | FR-014 明確要求新邏輯須有單元測試覆蓋 | ✅ |
 | VIII — 純函數/模組架構 | provider 安裝與 Core invocation 探測皆透過依賴注入，可在測試中覆寫 VS Code API、檔案系統與程序執行 | ✅ |
@@ -86,10 +86,12 @@ media/locales/*/messages.js             ← 15 個語系：新增安裝失敗、
 **關鍵發現摘要**：
 
 1. **installExtension 指令**：`workbench.extensions.installExtension` 為 VS Code 官方記載的內建指令。在 Open VSX 環境嘗試安裝不存在的 extension ID 時，預期會以 rejected Promise 回傳（需在實作階段以單元測試驗證確切錯誤類型）。
-2. **penv 自動建立**：PlatformIO IDE 與 pioarduino 在首次 activation 後**自動**執行安裝腳本建立 penv，無需使用者手動執行編譯。因此「需先執行 build」的說明已從規格移除。
+2. **penv 自動建立**：PlatformIO IDE 與 pioarduino 在首次 activation 後**自動**執行安裝腳本建立 penv，無需使用者手動執行編譯。安裝成功後呼叫 `platformio-ide.showHome`，明確觸發 activation 與 Core 初始化。
 3. **板子類型值**：`mainJson.board` 的值為 `'none'`（預設）、`'cyberbrick'`、`'txt'`，或 Arduino 板名（例如 `esp32dev`、`uno` 等非以上三者的值）。
 4. **提示 API**：`vscode.window.showInformationMessage(message, ...items)` 用於安裝失敗說明與成功後的 reload 按鈕；安裝前不另外呼叫。
 5. **直接安裝機制**：provider 缺失時立即呼叫 `workbench.extensions.installExtension`，避免增加前置確認步驟。
+6. **Home 失敗隔離**：`platformio-ide.showHome` 失敗不代表 provider 安裝失敗；只記錄不含第三方例外細節的警告，之後仍顯示 reload，不重新觸發 provider fallback。
+7. **並行 setup 合併**：`WebViewManager` 保存進行中的 provider setup Promise；重複開啟編輯器時不建立第二條流程，settle 後清除以保留重試能力。
 
 ## Phase 1：設計
 
@@ -104,7 +106,11 @@ media/locales/*/messages.js             ← 15 個語系：新增安裝失敗、
 webviewManager.createAndShowWebView()
   └── createDefaultDeps(localeService) → isProviderInstalled() ?
       ├── 已安裝 → 不觸發安裝
-      └── 未安裝 → showInstallNotification（所有板子，fire-and-forget）
+      └── 未安裝 → ensurePenvProviderSetup（所有板子，single-flight／fire-and-forget）
+            ├── provider 安裝成功 → await platformio-ide.showHome → reload 提示
+            ├── Home 失敗 → 記錄警告 → reload 提示
+            ├── setup 進行中再次觸發 → 共用既有 Promise，不重複副作用
+            └── provider 全部失敗 → Extensions 搜尋 + 手動安裝訊息
 
 [上傳路徑（簡化後）]
 arduinoUploader / micropythonUploader / serialMonitorService

--- a/specs/063-vscodium-openvsx-guided-install/quickstart.md
+++ b/specs/063-vscodium-openvsx-guided-install/quickstart.md
@@ -19,6 +19,8 @@
 **預期結果**：
 - 不顯示 Singular Blockly 自訂的安裝前確認按鈕
 - 直接啟動 PlatformIO provider 安裝
+- provider 安裝成功後自動開啟 PlatformIO Home，開始 Core 初始化
+- Home 命令完成或失敗隔離後，顯示既有 Reload Required 提示
 - Blockly 編輯器仍可正常操作
 
 **驗證指令**：
@@ -39,8 +41,9 @@ npm run lint
 
 **預期結果**：
 - PlatformIO IDE 開始安裝（Extensions 面板顯示安裝進度）
-- 安裝完成後 Singular Blockly 顯示「Reload Required」
-- Reload 後 PlatformIO 啟動並自動建立 `~/.platformio/penv/`
+- 安裝完成後自動執行 `platformio-ide.showHome`
+- PlatformIO Home／Core installer 開始初始化環境
+- Home 命令完成或失敗隔離後，Singular Blockly 顯示「Reload Required」
 
 ---
 
@@ -61,7 +64,8 @@ npm run lint
 - 不顯示 Singular Blockly 自訂的安裝前確認按鈕
 - 嘗試安裝 `platformio.platformio-ide` 失敗（Open VSX 無此 extension）
 - 自動 fallback 安裝 `pioarduino.pioarduino-ide`
-- pioarduino 安裝成功，VS Code 顯示 Reload Required
+- pioarduino 安裝成功後自動執行相同的 `platformio-ide.showHome` 命令
+- pioarduino Home／Core 初始化流程啟動，之後顯示 Reload Required
 
 **清理**：
 ```bash
@@ -103,11 +107,43 @@ rm -rf /tmp/vscodium-test
 - mock `executeCommand` 的 `installExtension` 呼叫均 reject
 - 驗證 `workbench.extensions.search` 被呼叫且參數為 `'platformio'`
 - 驗證顯示 `PENV_PROVIDER_INSTALL_FAILED` 訊息
+- 驗證不呼叫 `platformio-ide.showHome`
 - 驗證不顯示重新載入或「環境已就緒」訊息
 
 ---
 
-## 情境 7：Windows `pio.exe` 無法執行
+## 情境 7：Home 命令失敗
+
+**目的**：驗證 provider 已安裝但 Home contributed command rejected 時的錯誤隔離
+
+**設定步驟**（單元測試中驗證）：
+- mock provider `installExtension` 成功
+- mock `platformio-ide.showHome` reject
+- mock 使用者選擇 Reload Now
+
+**預期結果**：
+- 不重新嘗試安裝官方 provider 或 pioarduino
+- 記錄不含第三方例外細節的警告
+- 仍顯示既有 Reload Required，確認後呼叫 `workbench.action.reloadWindow`
+
+---
+
+## 情境 8：安裝期間重複開啟積木編輯器
+
+**目的**：驗證並行觸發共用同一條 provider setup
+
+**設定步驟**（單元測試中驗證）：
+- 保持第一個 `installExtension` Promise pending
+- 連續觸發兩次 provider setup
+- 完成第一條流程後再次觸發一次
+
+**預期結果**：
+- pending 期間只呼叫一次 `installExtension`、Home 與 reload
+- setup settle 後清除 in-flight 狀態，後續操作可重新偵測與重試
+
+---
+
+## 情境 9：Windows `pio.exe` 無法執行
 
 **目的**：驗證 Core 存在但 launcher 被拒絕時仍可使用
 
@@ -139,8 +175,14 @@ npm run compile-tests
 npx vscode-test --label unit \
   --run out/test/penvProviderService.test.js \
   --run out/test/services/micropythonUploaderAvailability.test.js
-# 預期：16 passing
+# 預期：17 passing
+
+# provider setup 與並行回歸測試（使用可用的 VS Code／VSCodium test host）
+npx vscode-test --label unit \
+  --run out/test/penvProviderService.test.js \
+  --run out/test/webviewManager.test.js
+# 預期：45 passing
 
 npm test
-# 目前完整基線：938 passing、1 pending，另有 1 個與本功能無關且已記錄的 OTA bootstrap 既有失敗
+# 目前完整基線：984 passing、1 pending，另有 1 個與本功能無關且已記錄的 OTA bootstrap 既有失敗
 ```

--- a/specs/063-vscodium-openvsx-guided-install/research.md
+++ b/specs/063-vscodium-openvsx-guided-install/research.md
@@ -16,14 +16,14 @@
 
 ## 決策 2：penv 建立時機
 
-**決策**：penv 由 PlatformIO IDE 或 pioarduino 在首次 activation 後**自動建立**，不需要使用者手動執行編譯。
+**決策**：penv 由 PlatformIO IDE 或 pioarduino 在首次 activation 後**自動建立**，不需要使用者手動執行編譯。provider 安裝成功後主動呼叫 `platformio-ide.showHome`，以觸發 activation 與 Core 初始化。
 
 **依據**：
 - 官方文件：「PlatformIO Core (CLI) is built into PlatformIO IDE and you will be able to use it within PlatformIO IDE Terminal.」
 - 安裝腳本（`get-platformio.py`）在 extension activation 時由 `platformio-node-helpers` / `pioarduino-node-helpers` 自動呼叫。
 - pioarduino 原始碼確認使用相同的安裝腳本，產生相同的 `~/.platformio/penv/` 結構。
 
-**影響**：從規格中移除「需先執行 build」的說明；重新載入提示不需要包含此步驟指引。
+**影響**：從規格中移除「需先執行 build」的說明；安裝後依序執行 Home／Core 初始化與既有重新載入提示，不需要加入 build 指引。
 
 ---
 
@@ -58,9 +58,20 @@
 
 ---
 
-## 決策 5：不以固定路徑輪詢宣告 Core 就緒
+## 決策 5：Home 初始化與 reload 的錯誤邊界
 
-**決策**：provider 安裝成功後只提示重新載入，不輪詢固定路徑，也不宣告 Core 已就緒。實際使用時由 PlatformIO invocation resolver 執行 `--version` 判斷。
+**決策**：任一 provider 安裝成功後，等待固定命令 `platformio-ide.showHome` 完成，再顯示既有 reload 提示。Home 命令 rejected 時只記錄不含例外細節的警告，仍繼續 reload；不得將 Home 失敗當成 marketplace 安裝失敗而改裝另一個 provider。
+
+**依據**：
+- 官方 PlatformIO IDE 與 pioarduino 共用 `platformio-ide.showHome` 命令 ID。
+- 執行 contributed command 會啟動 provider extension，進而進入其 Core installer。
+- provider 已成功安裝時，Home 錯誤屬初始化階段，與 `installExtension` fallback 的責任不同。
+
+---
+
+## 決策 6：不以固定路徑輪詢宣告 Core 就緒
+
+**決策**：provider 安裝成功後觸發 Home／Core 初始化並提示重新載入，但不輪詢固定路徑，也不宣告 Core 已就緒。實際使用時仍由 PlatformIO invocation resolver 執行 `--version` 判斷。
 
 **依據**：
 - extension 安裝成功與 PlatformIO Core 可執行是兩個不同狀態。
@@ -68,7 +79,17 @@
 
 ---
 
-## 決策 6：PlatformIO 啟動 fallback
+## 決策 7：provider setup single-flight
+
+**決策**：`WebViewManager` 在 provider setup 期間保存同一個 Promise。重複開啟積木編輯器時不再次呼叫安裝流程；Promise fulfilled 或 rejected 後都清除狀態，讓暫時性失敗可於下次操作重試。
+
+**依據**：積木編輯器命令可在前一次非同步安裝完成前再次觸發，VS Code 不保證替擴充功能序列化命令。若沒有 in-flight guard，即使 marketplace 合併重複下載，後續 Home 與 reload 仍可能重複執行。
+
+**安全性考量**：unexpected rejection 只記錄固定警告，不輸出第三方例外內容或本機路徑。
+
+---
+
+## 決策 8：PlatformIO 啟動 fallback
 
 **決策**：以 `{ command, prefixArgs }` 表示 PlatformIO 啟動方式，逐一實際執行 `--version`；Windows direct launcher 失敗後，改用同一 penv 的 `python.exe -m platformio`。
 

--- a/specs/063-vscodium-openvsx-guided-install/spec.md
+++ b/specs/063-vscodium-openvsx-guided-install/spec.md
@@ -17,6 +17,12 @@
 - Q：上傳時 provider 已安裝但 Core 仍在初始化（race condition）應如何處理？ → 實際探測所有可信候選；本次操作都不可執行時顯示初始化中或診斷指引，不在背景長時間輪詢固定路徑。
 - Q：如何判斷 PlatformIO Core 可用？ → 不以檔案存在作為成功條件；必須實際執行 `--version`。Windows 的 `pio.exe` 無法執行時，繼續嘗試同一 penv 的 `python.exe -m platformio`，並讓編譯、上傳與監控沿用成功的啟動方式。
 
+### 階段 2026-08-07
+
+- Q：provider 安裝完成後如何立即啟動 Core 初始化？ → 官方 PlatformIO IDE 與 pioarduino 安裝成功後都呼叫固定命令 `platformio-ide.showHome`，以啟動 provider 並進入其 Home／Core 初始化流程。
+- Q：Home 命令失敗時是否改裝另一個 provider？ → **否**。provider 已安裝成功，Home 失敗只記錄不含例外細節的警告，並繼續顯示既有重新載入提示，不將初始化錯誤誤判為 marketplace 安裝失敗。
+- Q：provider 安裝期間重複開啟積木編輯器時是否建立第二條流程？ → **否**。同一個 `WebViewManager` 共用進行中的 setup Promise；流程結束後清除狀態，讓暫時性失敗可在下次開啟時重試。
+
 ## 使用者情境與測試 *(必填)*
 
 ### 使用者故事 1 - VS Code 初次設定（優先級：P1）
@@ -30,7 +36,7 @@
 **驗收情境**：
 
 1. **給定** 任一板子工作區未安裝任何 penv provider，**當** 學生開啟積木編輯器，**則** 擴充功能直接開始安裝 `platformio.platformio-ide`，不顯示自訂的前置確認按鈕。
-2. **給定** provider 安裝完成，**當** 擴充功能顯示重新載入提示，**則** 學生可立即重新載入；penv 在 provider 首次啟動時自動建立，無需手動步驟。
+2. **給定** provider 安裝完成，**當** 自動安裝流程繼續執行，**則** 擴充功能先開啟 PlatformIO Home 觸發 provider 與 Core 初始化，再顯示既有重新載入提示。
 3. **給定** PlatformIO IDE 已安裝，**當** 擴充功能啟動，**則** 不重複觸發安裝。
 
 ---
@@ -46,8 +52,9 @@
 **驗收情境**：
 
 1. **給定** 未安裝任何 provider 且編輯器使用 Open VSX，**當** 學生開啟積木編輯器，**則** 嘗試安裝 `platformio.platformio-ide` 失敗後，自動 fallback 安裝 `pioarduino.pioarduino-ide`。
-2. **給定** pioarduino 已安裝，**當** 擴充功能啟動，**則** 不重複觸發安裝，所有上傳功能正常運作。
-3. **給定** 兩個 provider 均安裝失敗（例如：無網路），**當** 安裝嘗試失敗，**則** 開啟 Extensions 面板搜尋「platformio」，並以通知訊息說明可手動安裝 PlatformIO IDE 或 pioarduino。
+2. **給定** pioarduino fallback 安裝成功，**當** 自動安裝流程繼續執行，**則** 同樣呼叫 `platformio-ide.showHome` 啟動 pioarduino 的 Core 初始化流程。
+3. **給定** pioarduino 已安裝，**當** 擴充功能啟動，**則** 不重複觸發安裝或自動開啟 Home，所有上傳功能正常運作。
+4. **給定** 兩個 provider 均安裝失敗（例如：無網路），**當** 安裝嘗試失敗，**則** 開啟 Extensions 面板搜尋「platformio」，並以通知訊息說明可手動安裝 PlatformIO IDE 或 pioarduino。
 
 ---
 
@@ -105,6 +112,8 @@
 - `pio.exe` 存在但被系統拒絕執行？ → 不立即判定 unavailable，繼續嘗試同一 penv 的 `python.exe -m platformio`。
 - 板子類型尚未設定（`none`）的工作區？ → 與其他板子相同，維持 provider 前置安裝流程。
 - 積木編輯器尚未開啟就嘗試上傳？ → 上傳路徑只顯示簡明提示訊息，不重複觸發安裝。
+- provider 安裝成功但 `platformio-ide.showHome` 執行失敗？ → 記錄一般性警告並保留重新載入提示；不 fallback 安裝另一個 provider，也不暴露第三方例外細節。
+- provider 安裝尚未完成時連續開啟積木編輯器？ → 共用既有的 provider setup，不重複安裝、不重複開啟 Home，也不顯示多個 reload 提示；流程結束後允許下一次重新偵測。
 
 ## 需求 *(必填)*
 
@@ -116,7 +125,7 @@
 - **FR-004**：未偵測到任何 penv provider 時，系統必須直接呼叫 `workbench.extensions.installExtension` 啟動安裝，不顯示自訂的前置確認通知或按鈕。
 - **FR-005**：系統必須先嘗試安裝 `platformio.platformio-ide`；若安裝失敗（表示當前 marketplace 不提供此 extension），則自動 fallback 安裝 `pioarduino.pioarduino-ide`。
 - **FR-006**：若兩個 provider 均安裝失敗，系統必須開啟 Extensions 面板搜尋「platformio」，並在通知訊息中明確提及 PlatformIO IDE 和 pioarduino 兩個選項，供使用者手動選擇。
-- **FR-007**：只有 `installExtension` 成功時才顯示重新載入提示；兩個 provider 均安裝失敗時只開啟 Extensions 搜尋並顯示手動安裝訊息，不得顯示「環境已就緒」。重新載入後 penv 由 provider 首次啟動建立。
+- **FR-007**：只有 `installExtension` 成功時才進入 Home／重新載入路徑；兩個 provider 均安裝失敗時只開啟 Extensions 搜尋並顯示手動安裝訊息，不得開啟 Home 或顯示「環境已就緒」。
 - **FR-008**：Arduino 上傳時，若 `checkPioInstalled()` 回傳 false，顯示簡明提示訊息（引導學生開啟積木編輯器以自動安裝），不在上傳路徑重複觸發安裝流程。安裝已由積木編輯器開啟時處理。
 - **FR-009**：CyberBrick USB 上傳時，若 `checkPythonEnvironment()` 回傳 false，同 FR-008 處理方式（顯示簡明提示，不重複觸發安裝）。
 - **FR-010**：`micropythonUploader.ts` 中 `installMpremote()` 失敗時的 `details` 訊息，必須更新為同時提及 pioarduino 作為替代 provider，而非僅提及 PlatformIO。
@@ -128,28 +137,31 @@
 - **FR-016**：PlatformIO 啟動候選必須支援 `platformio-ide.customPATH`、`PLATFORMIO_CORE_DIR`、Windows 系統磁碟根目錄、預設 `~/.platformio` 與 `PATH`。
 - **FR-017**：若 direct launcher 失敗但 `python -m platformio` 成功，後續編譯、上傳與 Arduino Serial Monitor 必須沿用該 Python module 啟動方式。
 - **FR-018**：PlatformIO 診斷必須納入相同的 Core 位置候選；若 Python module fallback 成功，Core 項目顯示為可用，整體狀態可因其他工具缺失顯示為降級，但不得顯示 unavailable。
+- **FR-019**：官方 PlatformIO IDE 或 pioarduino 安裝成功後，系統必須先等待固定命令 `platformio-ide.showHome` 完成，再顯示既有重新載入提示；Home 命令失敗時只記錄不含例外細節的警告並繼續提示，不得重新觸發 provider fallback。
+- **FR-020**：provider setup 進行期間，重複開啟積木編輯器必須共用同一條 in-flight 流程；不得重複安裝 provider、開啟 Home 或顯示 reload。流程完成或失敗後必須清除 in-flight 狀態，以允許後續重新偵測與重試。
 
 ### 核心概念
 
 - **penv Provider**：已安裝的 VS Code 擴充功能（`platformio.platformio-ide` 或 `pioarduino.pioarduino-ide`），負責在首次啟動時建立並維護 PlatformIO Python 虛擬環境。
 - **penv**：PlatformIO Core 使用的 Python 虛擬環境；預設位於 `~/.platformio/penv/`，也可能由 `PLATFORMIO_CORE_DIR` 或 provider 設定改到其他位置。
-- **自動安裝流程（Automatic Provider Installation）**：未偵測到 penv provider 時直接啟動安裝；官方 provider 不可用時依序 fallback 到 pioarduino 與 Extensions 搜尋。
+- **自動安裝流程（Automatic Provider Installation）**：未偵測到 penv provider 時直接啟動安裝；官方 provider 不可用時依序 fallback 到 pioarduino 與 Extensions 搜尋。任一 provider 安裝成功後開啟 PlatformIO Home 觸發 Core 初始化，再保留重新載入提示。
 
 ## 成功指標 *(必填)*
 
 ### 可量測目標
 
-- **SC-001**：VSCodium 使用者在未安裝任何 provider 的情況下，能完成完整的引導安裝流程（開啟積木編輯器 → 自動安裝 → 重新載入 → 自動建立 penv），全程無不明錯誤。
+- **SC-001**：VSCodium 使用者在未安裝任何 provider 的情況下，能完成完整的引導安裝流程（開啟積木編輯器 → 自動安裝 → PlatformIO Home／Core 初始化 → 重新載入），全程無不明錯誤。
 - **SC-002**：VS Code 上已安裝 PlatformIO IDE 的使用者，行為零變化——不重複安裝，上傳流程不受影響。
 - **SC-003**：上傳時 penv 缺失，使用者在 3 秒內看到有行動指引的訊息，而非裸露的技術錯誤字串。
 - **SC-004**：908 筆以上的現有單元測試全數通過；新增測試涵蓋 provider 偵測、安裝結果、Windows Core fallback 及 Monitor 後端選擇。
 - **SC-005**：`npm run validate:i18n` 於新增 locale key 後驗證通過。
 - **SC-006**：VSCodium 1.121 搭配 pioarduino 1.4.4，擴充功能正常啟動，Blockly 編輯器、程式碼生成、CyberBrick 上傳皆正常運作。
+- **SC-007**：provider setup 尚未完成時連續觸發兩次積木編輯器，安裝、Home 與 reload 各只執行一次；流程完成後下一次觸發可重新偵測。
 
 ## 假設
 
 - `workbench.extensions.installExtension` 為 VS Code 官方記載的內建指令，在 VS Code、VSCodium、Firebase Studio、Google Antigravity 等目標編輯器均可使用。
-- 安裝完成後由本擴充功能顯示重新載入提示；使用者點擊後呼叫 VS Code 的重新載入指令。
+- 安裝完成後由本擴充功能呼叫 `platformio-ide.showHome` 啟動 provider／Core 初始化，再顯示既有重新載入提示；Home 命令 ID 在官方 PlatformIO IDE 與 pioarduino 中相容。
 - `pioarduino.pioarduino-ide` 預設建立與官方 PlatformIO extension 相容的 penv 結構；若設定自訂 Core 目錄，實際位置可不同於 `~/.platformio/penv/`。
 - 在 Open VSX 環境嘗試安裝 `platformio.platformio-ide` 會產生可捕捉的 rejection，使 fallback 到 pioarduino 得以觸發。
 - TypeScript 側的上傳錯誤 `message` 與 `details` 字串在現有程式碼中全為硬編碼英文；本規格不改變此模式（i18n 化屬既有技術債）。

--- a/specs/063-vscodium-openvsx-guided-install/tasks.md
+++ b/specs/063-vscodium-openvsx-guided-install/tasks.md
@@ -98,7 +98,7 @@ Phase 3 + Phase 4 + T018 → T019 → T020 → T021
 - [X] T019 執行 `npm run validate:i18n` 確認全部 15 個語系驗證通過，修正任何缺漏 key
 - [X] T020 執行 `npm test`：938 項通過、1 項略過；另有 1 項既有且與本 PR 無關的 MicroPython OTA 測試失敗，已明確記錄並交付測試 VSIX
 - [X] T021 minor 版本升級：更新 `package.json` 的 `version` 欄位，在 `CHANGELOG.md` 的「未發布」區段新增本功能條目（繁體中文 + English，含新功能說明與 VSCodium 相容性說明）
-- [ ] T022 手動驗收測試：依 `quickstart.md` Scenario 3 在 VSCodium + pioarduino 環境執行完整引導安裝流程（開啟積木編輯器 → 直接安裝 → reload → penv 自動建立 → CyberBrick 上傳成功），對應 SC-001；記錄測試結果
+- [ ] T022 手動驗收測試：依 `quickstart.md` Scenario 3 在 VSCodium + pioarduino 環境執行完整引導安裝流程（開啟積木編輯器 → 直接安裝 → PlatformIO Home／Core 初始化 → reload → CyberBrick 上傳成功），對應 SC-001；記錄測試結果
 
 ## Phase 7：Windows Core 啟動 fallback 與安裝狀態修正
 
@@ -108,6 +108,16 @@ Phase 3 + Phase 4 + T018 → T019 → T020 → T021
 - [X] T026 Arduino 編譯、上傳與 Serial Monitor 沿用 resolver 成功選出的啟動方式。
 - [X] T027 移除 CyberBrick Serial Monitor 的固定 penv guard，改用實際成功偵測裝置的後端。
 - [ ] T028 已產生 0.83.0 測試 VSIX；待在 Windows 非 ASCII 使用者路徑、`PLATFORMIO_CORE_DIR` 與被阻擋 `pio.exe` 情境完成手動驗收。
+
+## Phase 8：安裝後自動啟動 PlatformIO Home／Core 初始化
+
+- [X] T029 在 `src/services/penvProviderService.ts` 的 provider 安裝成功路徑依序等待 `platformio-ide.showHome` 與既有 reload 提示；Home 失敗只記錄一般性警告，不重新觸發 provider fallback。
+- [X] T030 在 `src/test/penvProviderService.test.ts` 覆蓋官方 provider、pioarduino fallback、Home rejected、manual-required 與既有 provider 不自動開啟 Home 的呼叫順序及錯誤隔離。
+- [X] T031 同步更新 feature 063 的規格、計畫、研究、資料模型、VS Code API 合約、quickstart，以及 `CHANGELOG.md` 未發布項目；不新增 i18n key 或版本發布。
+- [X] T032 執行 TypeScript 編譯、PenvProviderService 目標測試、ESLint 與完整 unit test：目標 15 項全數通過，完整 suite 為 982 passing、1 pending，另保留 1 項已記錄且與本功能無關的 OTA bootstrap 既有失敗；VS Code／VSCodium 乾淨環境手動驗收仍由 T022 追蹤。
+- [X] T033 在 `src/webview/webviewManager.ts` 以 in-flight Promise 合併並行 provider setup，settle 後清除狀態，unexpected rejection 僅記錄固定警告。
+- [X] T034 在 `src/test/webviewManager.test.ts` 驗證 pending 期間安裝、Home 與 reload 各只執行一次，且 settle 後可再次偵測。
+- [X] T035 同步文件並完成程式碼簡化與安全檢查；compile-tests、compile、lint 與 45 項聚焦測試通過，完整 suite 為 984 passing、1 pending，另保留 1 項已記錄且與本功能無關的 OTA bootstrap 既有失敗；本地 re-review 未發現新問題。
 
 ---
 
@@ -125,6 +135,13 @@ Phase 3 + Phase 4 + T018 → T019 → T020 → T021
 | T020 | T017、T019 |
 | T021 | T020 |
 | T022 | T020（需要可執行的 .vsix）|
+| T029 | T009 |
+| T030 | T029 |
+| T031 | T029、T030 |
+| T032 | T029–T031 |
+| T033 | T029 |
+| T034 | T033 |
+| T035 | T033、T034 |
 
 ## 平行執行範例
 

--- a/src/services/penvProviderService.ts
+++ b/src/services/penvProviderService.ts
@@ -107,6 +107,15 @@ export async function showInstallNotification(deps: PenvProviderServiceDeps): Pr
 	log('[PenvProviderService] Auto-installing penv provider', 'info');
 	const result = await attemptInstall(deps);
 	if (result.status === 'installed') {
+		try {
+			log(`[PenvProviderService] Opening PlatformIO Home for ${result.providerId}`, 'info');
+			await deps.executeCommand('platformio-ide.showHome');
+		} catch {
+			log(
+				`[PenvProviderService] Failed to open PlatformIO Home for ${result.providerId}; continuing with reload prompt`,
+				'warn'
+			);
+		}
 		await showReloadButton(deps);
 	}
 }

--- a/src/test/penvProviderService.test.ts
+++ b/src/test/penvProviderService.test.ts
@@ -107,7 +107,7 @@ describe('PenvProviderService', () => {
 	// ─── (c) showInstallNotification ──────────────────────────────────────
 
 	describe('showInstallNotification', () => {
-		it('should auto-install without showing a pre-install notification', async () => {
+		it('should open PlatformIO Home after auto-install and before showing reload', async () => {
 			const executeCommand = sinon.stub().resolves();
 			const showInformationMessage = sinon.stub().resolves(undefined);
 			const deps = createMockDeps({ executeCommand, showInformationMessage });
@@ -115,6 +115,18 @@ describe('PenvProviderService', () => {
 			assert.ok(
 				executeCommand.calledWith('workbench.extensions.installExtension', 'platformio.platformio-ide'),
 				'should trigger installExtension directly'
+			);
+			assert.ok(
+				executeCommand.calledWith('platformio-ide.showHome'),
+				'should open PlatformIO Home after installation'
+			);
+			assert.ok(
+				executeCommand.getCall(0).calledBefore(executeCommand.getCall(1)),
+				'should install the provider before opening PlatformIO Home'
+			);
+			assert.ok(
+				executeCommand.getCall(1).calledBefore(showInformationMessage.getCall(0)),
+				'should open PlatformIO Home before showing the reload prompt'
 			);
 		});
 
@@ -131,6 +143,45 @@ describe('PenvProviderService', () => {
 				executeCommand.calledWith('workbench.extensions.installExtension', 'pioarduino.pioarduino-ide'),
 				'should auto-fallback to pioarduino'
 			);
+			assert.ok(
+				executeCommand.calledWith('platformio-ide.showHome'),
+				'should open PlatformIO Home after installing pioarduino'
+			);
+			const pioarduinoInstallCall = executeCommand
+				.getCalls()
+				.find(call => call.args[1] === 'pioarduino.pioarduino-ide');
+			const homeCall = executeCommand.getCalls().find(call => call.args[0] === 'platformio-ide.showHome');
+			assert.ok(
+				pioarduinoInstallCall && homeCall && pioarduinoInstallCall.calledBefore(homeCall),
+				'should finish installing pioarduino before opening PlatformIO Home'
+			);
+			assert.ok(
+				homeCall && homeCall.calledBefore(showInformationMessage.getCall(0)),
+				'should open PlatformIO Home before showing the reload prompt'
+			);
+		});
+
+		it('should still offer reload when opening PlatformIO Home fails', async () => {
+			const executeCommand = sinon.stub();
+			executeCommand.withArgs('platformio-ide.showHome').rejects(new Error('Command unavailable'));
+			executeCommand.resolves();
+			const showInformationMessage = sinon.stub().resolves('Reload Now');
+			const deps = createMockDeps({ executeCommand, showInformationMessage });
+
+			await showInstallNotification(deps);
+
+			assert.strictEqual(
+				executeCommand
+					.getCalls()
+					.filter(call => call.args[0] === 'workbench.extensions.installExtension').length,
+				1,
+				'Home failure must not trigger another provider installation'
+			);
+			assert.ok(showInformationMessage.calledOnce, 'should retain the existing reload prompt');
+			assert.ok(
+				executeCommand.calledWith('workbench.action.reloadWindow'),
+				'should still reload when the user confirms'
+			);
 		});
 
 		it('should not report ready or reload when both provider installs fail', async () => {
@@ -145,6 +196,10 @@ describe('PenvProviderService', () => {
 			await showInstallNotification(deps);
 
 			assert.ok(executeCommand.calledWith('workbench.extensions.search', 'platformio'));
+			assert.ok(
+				executeCommand.neverCalledWith('platformio-ide.showHome'),
+				'failed provider installation must not open PlatformIO Home'
+			);
 			assert.ok(
 				executeCommand.neverCalledWith('workbench.action.reloadWindow'),
 				'failed installation must not offer or trigger reload'
@@ -184,6 +239,10 @@ describe('PenvProviderService', () => {
 				await showInstallNotification(deps);
 			}
 			assert.ok(executeCommand.notCalled, 'no install when provider present');
+			assert.ok(
+				executeCommand.neverCalledWith('platformio-ide.showHome'),
+				'no automatic Home opening when provider was already present'
+			);
 		});
 
 		it('[US2] should fallback to pioarduino when platformio install fails', async () => {

--- a/src/test/webviewManager.test.ts
+++ b/src/test/webviewManager.test.ts
@@ -210,6 +210,84 @@ describe('WebView Manager', () => {
 		// 注意：我們不能驗證 reveal 的 calledOnce 屬性，因為它是真實方法而非 stub
 	});
 
+	it('should coalesce concurrent provider setup attempts and allow retry after completion', async () => {
+		let resolveInstall!: () => void;
+		const installPending = new Promise<void>(resolve => {
+			resolveInstall = resolve;
+		});
+		const executeCommand = sinon.stub();
+		executeCommand
+			.withArgs('workbench.extensions.installExtension', 'platformio.platformio-ide')
+			.returns(installPending);
+		executeCommand.resolves();
+		const showInformationMessage = sinon.stub().resolves(undefined);
+		const deps = {
+			getExtension: sinon.stub().returns(undefined),
+			executeCommand,
+			showInformationMessage,
+		};
+		const manager = webViewManager as any;
+
+		manager.ensurePenvProviderSetup(deps);
+		const firstSetup = manager.penvProviderSetup as Promise<void>;
+		manager.ensurePenvProviderSetup(deps);
+
+		assert.strictEqual(
+			executeCommand.withArgs('workbench.extensions.installExtension', 'platformio.platformio-ide').callCount,
+			1,
+			'concurrent attempts should share the in-flight provider setup'
+		);
+
+		resolveInstall();
+		await firstSetup;
+
+		assert.strictEqual(executeCommand.withArgs('platformio-ide.showHome').callCount, 1);
+		assert.strictEqual(showInformationMessage.callCount, 1);
+
+		manager.ensurePenvProviderSetup(deps);
+		await (manager.penvProviderSetup as Promise<void>);
+
+		assert.strictEqual(
+			executeCommand.withArgs('workbench.extensions.installExtension', 'platformio.platformio-ide').callCount,
+			2,
+			'a later attempt should be allowed after the previous setup completes'
+		);
+	});
+
+	it('should allow provider setup retry after an unexpected rejection', async () => {
+		const executeCommand = sinon.stub();
+		executeCommand
+			.withArgs('workbench.extensions.installExtension', sinon.match.string)
+			.rejects(new Error('Provider unavailable'));
+		executeCommand
+			.withArgs('workbench.extensions.search', 'platformio')
+			.rejects(new Error('Extensions search unavailable'));
+		const deps = {
+			getExtension: sinon.stub().returns(undefined),
+			executeCommand,
+			showInformationMessage: sinon.stub().resolves(undefined),
+		};
+		const manager = webViewManager as any;
+
+		manager.ensurePenvProviderSetup(deps);
+		await assert.rejects(manager.penvProviderSetup as Promise<void>);
+
+		manager.ensurePenvProviderSetup(deps);
+		await assert.rejects(manager.penvProviderSetup as Promise<void>);
+
+		assert.strictEqual(
+			executeCommand
+				.getCalls()
+				.filter(
+					call =>
+						call.args[0] === 'workbench.extensions.installExtension' &&
+						call.args[1] === 'platformio.platformio-ide'
+				).length,
+			2,
+			'an unexpected rejection should not permanently block later setup attempts'
+		);
+	});
+
 	it('should show error if no workspace folder open', async () => {
 		// 設定沒有開啟工作區
 		vscodeMock.workspace.workspaceFolders = undefined;

--- a/src/webview/webviewManager.ts
+++ b/src/webview/webviewManager.ts
@@ -16,7 +16,12 @@ import { BoardConfigKey, LoadWorkspaceStateMessage, PreviewWarning, SetBoardMess
 import { TxtVirtualControlsDocument, normalizeTxtVirtualControlsDocument } from '../types/txtVirtualControls';
 import { AIModelManager } from '../services/aiModelManager';
 import { AIStatusBar } from '../services/aiStatusBar';
-import { isProviderInstalled, showInstallNotification, createDefaultDeps } from '../services/penvProviderService';
+import {
+	createDefaultDeps,
+	isProviderInstalled,
+	showInstallNotification,
+	type PenvProviderServiceDeps,
+} from '../services/penvProviderService';
 
 /**
  * 開發板值映射表
@@ -261,6 +266,7 @@ export class WebViewManager {
 	private internalUpdateCount: number = 0; // 避免內部更新觸發 FileWatcher
 	private aiModelManager?: AIModelManager;
 	private aiStatusBar?: AIStatusBar;
+	private penvProviderSetup?: Promise<void>;
 	/** TXT Controller I/O Test Panel — T034 */
 
 	/**
@@ -293,6 +299,23 @@ export class WebViewManager {
 		}
 	}
 
+	private ensurePenvProviderSetup(deps: PenvProviderServiceDeps): void {
+		if (this.penvProviderSetup || isProviderInstalled(deps)) {
+			return;
+		}
+
+		this.penvProviderSetup = showInstallNotification(deps);
+		void this.penvProviderSetup.then(
+			() => {
+				this.penvProviderSetup = undefined;
+			},
+			() => {
+				this.penvProviderSetup = undefined;
+				log('[WebViewManager] PlatformIO provider setup failed unexpectedly', 'warn');
+			}
+		);
+	}
+
 	/**
 	 * 建立並顯示 WebView 面板
 	 */
@@ -302,9 +325,7 @@ export class WebViewManager {
 		const isTestEnvironmentPenv = process.env.NODE_ENV === 'test';
 		if (!isTestEnvironmentPenv) {
 			const penvDeps = createDefaultDeps(this.localeService);
-			if (!isProviderInstalled(penvDeps)) {
-				void showInstallNotification(penvDeps);
-			}
+			this.ensurePenvProviderSetup(penvDeps);
 		}
 
 		// 檢查工作區


### PR DESCRIPTION
## 變更摘要 Summary

PlatformIO IDE 或 pioarduino provider 自動安裝成功後，先開啟 PlatformIO Home 觸發 Core 初始化，再顯示既有 Reload 提示。安裝期間的重複編輯器操作會共用同一條 setup 流程，避免重複安裝、Home 與通知。

## 相關 Spec Related Spec

- Spec: `specs/063-vscodium-openvsx-guided-install/spec.md`
- Tasks: `specs/063-vscodium-openvsx-guided-install/tasks.md`

## 變更類型 Type of Change

- [x] 🐛 Bug 修復
- [ ] ✨ 新功能
- [ ] 💥 破壞性變更
- [x] 📝 文件更新

## 變更內容 Changes

- provider 安裝成功後依序執行 `platformio-ide.showHome` 與 Reload 提示
- Home 失敗時保留安裝結果，不誤觸 provider fallback
- 以 in-flight Promise 合併重複 setup，settle 後允許重試
- 補齊官方 provider、pioarduino、Home rejected 與並行流程測試

## 測試計劃 Test Plan

- [x] `npm run compile-tests`
- [x] 聚焦測試：45 passing
- [x] `npm run lint`
- [x] `npm run compile`
- [x] 完整 suite：984 passing、1 pending
- [ ] 既有 OTA bootstrap 測試仍有 1 項與本修正無關的已知失敗
- [ ] 乾淨 VS Code／VSCodium 手動驗收由 T022 持續追蹤

## 安全與相容性 Security and Compatibility

- 命令 ID 與 provider ID 均為固定值
- 不記錄第三方例外內容或敏感路徑
- 已安裝 provider 的既有使用者不會自動開啟 Home
