### PR TITLE
fix(ci): 修復 annotated tag 發布驗證

### DIFF
--- a/.github/skills/pr-review-release/SKILL.md
+++ b/.github/skills/pr-review-release/SKILL.md
@@ -182,6 +182,14 @@ gh run view {RUN_ID} --json attempt,status,conclusion,jobs,url
 
 重跑後必須等待同一 run 的新 attempt 完成並再次確認 conclusion；若仍失敗就停止。不得重建 tag，也不得重發已成功的發布端。
 
+若 tag 觸發的 run 在任何發布 job 開始前，因 workflow 本身的缺陷於 `quality` 階段失敗，先用新 PR 修正 workflow；修正合併後可從 `master` 手動 dispatch 同一個既有 annotated tag。這是不可變 tag 的復原入口，不得用來改換 release commit：
+
+```bash
+gh workflow run publish.yml --ref master -f release_tag=v{VERSION}
+```
+
+手動 run 仍必須驗證 tag 格式、annotated object、tag 指向的 commit、版本檔與雙語 CHANGELOG，並從該 tag checkout 建置唯一 VSIX。
+
 市集的第一次 publish 必須嚴格拒絕重複版本；只有 `github.run_attempt > 1` 的重跑 job 可使用 `--skip-duplicate`，以復原伺服器已接受但 runner 未取得成功回應的情況。
 
 ### 5.4 驗證三個發布端

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.release_tag || github.sha }}
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -78,6 +80,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.release_tag || github.sha }}
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -138,7 +142,18 @@ jobs:
       - name: Checkout repository and tags
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          ref: ${{ inputs.release_tag || github.sha }}
           fetch-depth: 0
+
+      - name: Restore annotated release tag object
+        if: env.RELEASE_TAG != ''
+        shell: bash
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          git fetch --force --no-tags origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,18 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing annotated vX.Y.Z tag to recover without recreating it
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -19,7 +25,7 @@ jobs:
     permissions:
       contents: read
     with:
-      release_tag: ${{ github.ref_name }}
+      release_tag: ${{ inputs.release_tag || github.ref_name }}
 
   github-release:
     name: Publish GitHub Release
@@ -33,7 +39,7 @@ jobs:
       ARTIFACT_NAME: ${{ needs.quality.outputs['artifact-name'] }}
       VSIX_NAME: ${{ needs.quality.outputs['vsix-name'] }}
       CHECKSUM_NAME: ${{ needs.quality.outputs['checksum-name'] }}
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - name: Download verified release artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -79,6 +85,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref_name }}
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -121,6 +129,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref_name }}
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -165,7 +175,7 @@ jobs:
       ARTIFACT_NAME: ${{ needs.quality.outputs['artifact-name'] }}
       VSIX_NAME: ${{ needs.quality.outputs['vsix-name'] }}
       CHECKSUM_NAME: ${{ needs.quality.outputs['checksum-name'] }}
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       GITHUB_RELEASE_RESULT: ${{ needs.github-release.result }}
       MARKETPLACE_RESULT: ${{ needs.publish-marketplace.result }}
       OPEN_VSX_RESULT: ${{ needs.publish-open-vsx.result }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [未發布] Unreleased
 
+### 🐛 修復 Bug Fixes
+
+- 修正 GitHub Actions checkout 將 annotated tag 的本地 ref 展開成 commit，造成發布 metadata gate 誤判；並加入不重建既有 tag 的安全復原入口
+  Fixed GitHub Actions checkout peeling the local annotated-tag ref into a commit and triggering a false metadata-gate failure, and added safe recovery for an existing tag without recreating it
+
 ## [0.85.1] - 2026-08-10
 
 ### 🐛 修復 Bug Fixes

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -63,6 +63,14 @@ gh run rerun RUN_ID --failed
 
 不得刪除／重建 tag，也不得重發已成功的市集。市集的第一次 publish 仍嚴格拒絕重複版本；只有 workflow 重跑時才使用 `--skip-duplicate`，用來復原「市集已接受、runner 卻回報失敗」的不明狀態。正式發布不在本機執行 `vsce package` 或 `gh release create`。
 
+若 tag 觸發的 run 在三個發布 job 開始前，因 workflow 缺陷於 `quality` 階段失敗，先以新 PR 修正 workflow。合併後從 `master` 對同一個既有 annotated tag 執行復原，不刪除或重建 tag：
+
+```bash
+gh workflow run publish.yml --ref master -f release_tag=vX.Y.Z
+```
+
+復原 run 仍會 checkout 該 tag、重新取得遠端 annotated tag object，並驗證 tag、checkout commit、版本檔及雙語 CHANGELOG 完全一致後才建置與發布。
+
 ## GitHub 管理設定
 
 下列設定是 repository 管理狀態，無法只靠提交檔案完成。人工發布核准固定由發布擁有者在 `pr-review-release` Phase 3.5 明確給予。

--- a/scripts/release/prepare-release.test.js
+++ b/scripts/release/prepare-release.test.js
@@ -126,6 +126,11 @@ describe('release preparation', () => {
 describe('publish workflow retry contract', () => {
 	const workflow = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'workflows', 'publish.yml'), 'utf8');
 
+	it('supports recovery from an existing immutable annotated tag', () => {
+		assert.match(workflow, /workflow_dispatch:[\s\S]*?release_tag:/);
+		assert.match(workflow, /release_tag: \$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
+	});
+
 	it('keeps first marketplace attempts strict', () => {
 		const strictSteps = workflow.match(/if: github\.run_attempt == 1[\s\S]*?run: [^\n]+/gu) || [];
 		assert.strictEqual(strictSteps.length, 2);
@@ -157,5 +162,15 @@ describe('GitHub workflow context contract', () => {
 		);
 		assert.match(workflow, /tar -czf coverage-linux\.tar\.gz coverage/);
 		assert.match(workflow, /path: coverage-linux\.tar\.gz/);
+	});
+
+	it('checks out release jobs at the requested tag and restores its annotated object', () => {
+		const workflow = fs.readFileSync(
+			path.join(__dirname, '..', '..', '.github', 'workflows', 'ci.yml'),
+			'utf8'
+		);
+		const releaseRefs = workflow.match(/ref: \$\{\{ inputs\.release_tag \|\| github\.sha \}\}/gu) || [];
+		assert.strictEqual(releaseRefs.length, 3);
+		assert.match(workflow, /git fetch --force --no-tags origin "refs\/tags\/\$\{RELEASE_TAG\}:refs\/tags\/\$\{RELEASE_TAG\}"/);
 	});
 });


### PR DESCRIPTION
## 摘要

- 修正 actions/checkout 將 runner 內的 annotated tag ref 展開成 commit，造成發布 metadata gate 誤判
- 新增從 master 手動 dispatch 既有 immutable annotated tag 的安全復原入口
- 所有 CI 與發布 job 均 checkout 指定 tag，package job 重新抓取遠端 annotated tag object 後再驗證
- 更新發布技能、CI/CD 文件、CHANGELOG 與 workflow contract tests

## 背景

v0.85.1 的首次 tag run 在任何發布 job 開始前，於 quality/package metadata 驗證失敗。遠端 v0.85.1 仍是正確且不可變的 annotated tag，指向 cdadfc5582710d6914a73559085f2dd05b8d540c，因此不刪除或重建 tag。

## 驗證

- npm run test:release：17 passing
- npm run ci:static：通過
- 隔離 clone 重現 tag ref 被改成 commit，再執行 workflow fetch 後恢復為 tag，且仍指向 cdadfc5582710d6914a73559085f2dd05b8d540c
- git diff --check：通過
- Secrets 僅以 GitHub Actions secrets context 引用，沒有敏感值進入 repository 或 log

## 發布復原

本 PR 合併且 CI 全綠後，從 master 手動執行 publish.yml，輸入既有 release_tag=v0.85.1。workflow 仍會驗證 annotated tag、commit、package/lockfile/CHANGELOG 一致性，並由該 tag 建置唯一 VSIX。