### PR TITLE
fix(ci): 補強 GitHub Release 復原流程

### DIFF
--- a/.github/skills/pr-review-release/SKILL.md
+++ b/.github/skills/pr-review-release/SKILL.md
@@ -190,6 +190,16 @@ gh workflow run publish.yml --ref master -f release_tag=v{VERSION}
 
 手動 run 仍必須驗證 tag 格式、annotated object、tag 指向的 commit、版本檔與雙語 CHANGELOG，並從該 tag checkout 建置唯一 VSIX。
 
+若 Marketplace 與 Open VSX 已成功，但 GitHub Release 因 workflow 缺陷失敗，不得建立新 VSIX 或重發市集。先用 PR 修正 workflow，再以原失敗 run 的同一 artifact 只補 GitHub Release：
+
+```bash
+gh workflow run recover-github-release.yml --ref master \
+  -f release_tag=v{VERSION} \
+  -f source_run_id={FAILED_RUN_ID}
+```
+
+GitHub Release 復原 workflow 必須驗證來源是失敗的正式發布 run，並重新驗證 annotated tag、release metadata、VSIX archive 與 SHA-256。
+
 市集的第一次 publish 必須嚴格拒絕重複版本；只有 `github.run_attempt > 1` 的重跑 job 可使用 `--skip-duplicate`，以復原伺服器已接受但 runner 未取得成功回應的情況。
 
 ### 5.4 驗證三個發布端

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
       VSIX_NAME: ${{ needs.quality.outputs['vsix-name'] }}
       CHECKSUM_NAME: ${{ needs.quality.outputs['checksum-name'] }}
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Download verified release artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -176,6 +177,7 @@ jobs:
       VSIX_NAME: ${{ needs.quality.outputs['vsix-name'] }}
       CHECKSUM_NAME: ${{ needs.quality.outputs['checksum-name'] }}
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      GH_REPO: ${{ github.repository }}
       GITHUB_RELEASE_RESULT: ${{ needs.github-release.result }}
       MARKETPLACE_RESULT: ${{ needs.publish-marketplace.result }}
       OPEN_VSX_RESULT: ${{ needs.publish-open-vsx.result }}

--- a/.github/workflows/recover-github-release.yml
+++ b/.github/workflows/recover-github-release.yml
@@ -1,0 +1,137 @@
+name: Recover GitHub Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing annotated vX.Y.Z tag to recover
+        required: true
+        type: string
+      source_run_id:
+        description: Failed Publish VS Code Extension run containing the shared artifact
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-release-recovery-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    name: Recover GitHub Release from shared artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: release
+    permissions:
+      actions: read
+      contents: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Validate recovery inputs
+        shell: bash
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid source run ID: $SOURCE_RUN_ID" >&2
+            exit 1
+          fi
+
+      - name: Confirm source is a failed publish run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" > source-run.json
+          jq -e '.name == "Publish VS Code Extension" and .conclusion == "failure"' source-run.json
+
+      - name: Checkout release tag and tags
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.release_tag }}
+          fetch-depth: 0
+
+      - name: Restore annotated release tag object
+        shell: bash
+        run: git fetch --force --no-tags origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+
+      - name: Set up Node.js 22.16.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.16.0
+
+      - name: Verify release metadata
+        id: metadata
+        run: npm run release:prepare -- --verify-tag
+
+      - name: Download shared artifact from failed run
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ steps.metadata.outputs.artifact-name }}
+          path: release-artifacts
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Verify shared artifact
+        shell: bash
+        env:
+          VERSION: ${{ steps.metadata.outputs.version }}
+          VSIX_NAME: ${{ steps.metadata.outputs.vsix-name }}
+          CHECKSUM_NAME: ${{ steps.metadata.outputs.checksum-name }}
+        run: |
+          cd release-artifacts
+          unzip -tqq "$VSIX_NAME"
+          sha256sum --check "$CHECKSUM_NAME"
+          jq -e \
+            --arg tag "$RELEASE_TAG" \
+            --arg version "$VERSION" \
+            --arg vsix "$VSIX_NAME" \
+            --arg checksum "$CHECKSUM_NAME" \
+            '.tag == $tag and .version == $version and .vsix == $vsix and .checksumFile == $checksum' \
+            release-metadata.json
+
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VSIX_NAME: ${{ steps.metadata.outputs.vsix-name }}
+          CHECKSUM_NAME: ${{ steps.metadata.outputs.checksum-name }}
+        run: |
+          if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" \
+              "release-artifacts/$VSIX_NAME" \
+              "release-artifacts/$CHECKSUM_NAME" \
+              --clobber
+            gh release edit "$RELEASE_TAG" \
+              --title "Singular Blockly $RELEASE_TAG" \
+              --notes-file release-artifacts/release-notes.md \
+              --latest
+          else
+            gh release create "$RELEASE_TAG" \
+              "release-artifacts/$VSIX_NAME" \
+              "release-artifacts/$CHECKSUM_NAME" \
+              --verify-tag \
+              --title "Singular Blockly $RELEASE_TAG" \
+              --notes-file release-artifacts/release-notes.md \
+              --latest
+          fi
+
+      - name: Verify GitHub Release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VSIX_NAME: ${{ steps.metadata.outputs.vsix-name }}
+          CHECKSUM_NAME: ${{ steps.metadata.outputs.checksum-name }}
+        run: |
+          gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' > release-assets.txt
+          grep -Fx "$VSIX_NAME" release-assets.txt
+          grep -Fx "$CHECKSUM_NAME" release-assets.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 修正 GitHub Actions checkout 將 annotated tag 的本地 ref 展開成 commit，造成發布 metadata gate 誤判；並加入不重建既有 tag 的安全復原入口
   Fixed GitHub Actions checkout peeling the local annotated-tag ref into a commit and triggering a false metadata-gate failure, and added safe recovery for an existing tag without recreating it
+- 修正 GitHub Release job 缺少明確 repository context，並加入沿用原發布 run artifact、只補失敗 GitHub Release 的復原流程
+  Fixed missing repository context in the GitHub Release job and added recovery that reuses the original publish-run artifact to repair only a failed GitHub Release
 
 ## [0.85.1] - 2026-08-10
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -71,6 +71,16 @@ gh workflow run publish.yml --ref master -f release_tag=vX.Y.Z
 
 復原 run 仍會 checkout 該 tag、重新取得遠端 annotated tag object，並驗證 tag、checkout commit、版本檔及雙語 CHANGELOG 完全一致後才建置與發布。
 
+若同一 run 的 Marketplace 與 Open VSX 已成功，但 GitHub Release 因 workflow 缺陷失敗，先用 PR 修正 workflow，再從原失敗 run 的 artifact 只補 GitHub Release：
+
+```bash
+gh workflow run recover-github-release.yml --ref master \
+  -f release_tag=vX.Y.Z \
+  -f source_run_id=FAILED_RUN_ID
+```
+
+復原 workflow 只接受失敗的 `Publish VS Code Extension` run，會重新驗證 annotated tag、release metadata、VSIX archive 與 SHA-256，且不含 VS Code Marketplace 或 Open VSX 發布步驟。
+
 ## GitHub 管理設定
 
 下列設定是 repository 管理狀態，無法只靠提交檔案完成。人工發布核准固定由發布擁有者在 `pr-review-release` Phase 3.5 明確給予。
@@ -82,7 +92,7 @@ gh workflow run publish.yml --ref master -f release_tag=vX.Y.Z
 - 建立名為 `release` 的 environment。
 - 既有 repository secrets `VSCE_PAT`、`OVSX_PAT` 可直接沿用；GitHub 不提供既有 secret 值的讀回或複製功能。
 - 日後輪替 PAT 時，可改存為同名 environment secrets；environment secrets 會覆蓋同名 repository secrets。
-- Deployment branches and tags 限制為 `v*` tags。
+- Deployment branches and tags 限制為 `v*` tags 與受保護的 `master` branch；`master` 僅供不可變 tag 與原 run artifact 的復原 workflow 使用。
 - 不新增 environment reviewer；人工發布核准由 `pr-review-release` Phase 3.5 負責。
 
 ### `master` ruleset

--- a/scripts/release/prepare-release.test.js
+++ b/scripts/release/prepare-release.test.js
@@ -142,10 +142,39 @@ describe('publish workflow retry contract', () => {
 		assert.strictEqual(retrySteps.length, 2);
 		assert.ok(retrySteps.every(step => step.includes('--skip-duplicate')));
 	});
+
+	it('provides explicit repository context to GitHub CLI jobs', () => {
+		const repositoryContexts = workflow.match(/GH_REPO: \$\{\{ github\.repository \}\}/gu) || [];
+		assert.strictEqual(repositoryContexts.length, 2);
+	});
+});
+
+describe('GitHub Release recovery workflow contract', () => {
+	const workflow = fs.readFileSync(
+		path.join(__dirname, '..', '..', '.github', 'workflows', 'recover-github-release.yml'),
+		'utf8'
+	);
+
+	it('reuses a failed publish run artifact without republishing marketplaces', () => {
+		assert.match(workflow, /source_run_id:/);
+		assert.match(workflow, /actions: read/);
+		assert.match(workflow, /github-token: \$\{\{ github\.token \}\}/);
+		assert.match(workflow, /run-id: \$\{\{ inputs\.source_run_id \}\}/);
+		assert.match(workflow, /\.name == "Publish VS Code Extension" and \.conclusion == "failure"/);
+		assert.ok(!workflow.includes('vsce publish'));
+		assert.ok(!workflow.includes('ovsx publish'));
+	});
+
+	it('revalidates the tag, metadata, archive, and checksum before publishing', () => {
+		assert.match(workflow, /npm run release:prepare -- --verify-tag/);
+		assert.match(workflow, /unzip -tqq "\$VSIX_NAME"/);
+		assert.match(workflow, /sha256sum --check "\$CHECKSUM_NAME"/);
+		assert.match(workflow, /GH_REPO: \$\{\{ github\.repository \}\}/);
+	});
 });
 
 describe('GitHub workflow context contract', () => {
-	for (const workflowName of ['ci.yml', 'i18n-audit.yml', 'publish.yml']) {
+	for (const workflowName of ['ci.yml', 'i18n-audit.yml', 'publish.yml', 'recover-github-release.yml']) {
 		it(`${workflowName} does not evaluate runner.temp before a runner exists`, () => {
 			const workflow = fs.readFileSync(
 				path.join(__dirname, '..', '..', '.github', 'workflows', workflowName),


### PR DESCRIPTION
## 摘要

- 為 Publish GitHub Release 與最終驗證提供明確 GH_REPO context
- 新增只從既有失敗 publish run 下載原 artifact 的 GitHub Release 復原 workflow
- 復原前重新驗證 annotated tag、來源 workflow、release metadata、VSIX archive 與 SHA-256
- 復原 workflow 不包含 VS Code Marketplace 或 Open VSX 發布步驟
- 同步更新 release contract tests、發布技能、CI/CD 文件與雙語 CHANGELOG

## 背景

v0.85.1 的 Publish run 31393956109 已由同一 artifact 成功發布到 VS Code Marketplace 與 Open VSX；GitHub Release 因 job 沒有 repository context 而失敗。原 artifact ID 9065120977 仍有效，因此不得重新建置或重發市集。

## 驗證

- npm run ci:static：通過
- npm run test:unit:ci：1040 passing、1 pending
- npm run test:release：21 passing
- npm run release:prepare：通過
- publish.yml 與 recover-github-release.yml YAML 解析通過
- 原 artifact VSIX archive、metadata 與 checksum 驗證通過
- SHA-256：d24bae0d1a47b334719ce1a55cc3af44df018a94f9253f594e82aea996647a71
- 安全 re-review：最小 GITHUB_TOKEN 權限、release tag 與 run ID 輸入驗證、無敏感值或市集重發路徑

## 發布資訊

- Version：v0.85.1
- 不建立、移動或重建 tag
- 本 PR 合併後只執行 recover-github-release.yml，來源 run 固定為 31393956109