### PR TITLE
feat(skills): 新增 Dependabot PR 管理流程

### DIFF
--- a/.agents/skills/manage-dependabot-prs
+++ b/.agents/skills/manage-dependabot-prs
@@ -1,0 +1,1 @@
+../../.github/skills/manage-dependabot-prs

--- a/.github/skills/manage-dependabot-prs/SKILL.md
+++ b/.github/skills/manage-dependabot-prs/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: manage-dependabot-prs
+description: 盤點、排序、分類並逐項處理本專案的 Dependabot Pull Requests。當使用者提到 Dependabot PR、依賴更新 PR、GitHub Actions 更新、套件升級排序、批次依賴維護、評估 dependency PR 是否需要 SDD、合併或關閉 Dependabot PR 時使用。先以唯讀 triage 區分 Security Update 與 Version Update、建立相依順序與 SDD gate，再一次處理一個獨立風險群組；不得把例行版本更新誤當安全發布。Triage, prioritize, classify, and safely resolve this repository's Dependabot PRs, including SDD decisions and routing security updates to the dedicated vulnerability workflow.
+---
+
+# Dependabot PR 管理
+
+把大量自動 PR 轉成可審查的工作佇列。先完成全體唯讀盤點並取得使用者對順序與處置的核准，再一次處理一個獨立風險群組。
+
+## 核心規則
+
+- Triage 階段只讀取資料；不得 comment、rebase、close、merge、push 或修改 `dependabot.yml`。
+- 不依 PR 標題猜測是否為安全更新；交叉比對 Dependabot Alerts、PR body／files 與 `npm audit`。
+- Security Update 與 Version Update 分流。只有安全公告／Alert／audit finding 才使用安全修補發布流程。
+- 不按 PR 編號盲目處理。先排序 urgency、blast radius、依賴關係與 CI 狀態。
+- 一次只實作一個獨立風險群組。上一項未合併且 `master` 未同步前，不開始下一項。
+- 不直接把額外 commits 推到 Dependabot bot branch。需要相容性修正時，從最新 `master` 建立 human-owned `codex/deps-*` 分支與替代 PR。
+- 不使用 `npm audit fix --force`、寬鬆 `npm update` 或未限定範圍的 overrides。
+- 依賴與 Actions 的 breaking change 必須查官方 release notes／migration guide；技術判斷只採一手來源。
+
+## Phase 0：確認操作模式
+
+把請求分類為：
+
+- **Triage only**：盤點、排序、分群、SDD 判斷；完成報告後停止。
+- **Resolve one item**：處理已核准佇列中的一項或一個同風險群組。
+- **Reconfigure Dependabot**：調整 grouping、cooldown、ignore 或 open PR limit；視為獨立設定變更，不混入套件升級。
+
+使用者只說「處理 Dependabot PR」時，預設先執行 Triage only，不得直接合併。
+
+## Phase 1：唯讀盤點
+
+1. 確認 repo、default branch、本地分支與工作區狀態。
+2. 取得所有 open Dependabot PR，至少包含：number、title、URL、author、head/base、created/updated time、labels、body、files、mergeability 與 checks。
+3. 取得 open Dependabot Security Alerts，並執行本地 `npm audit` 交叉比對。
+4. 對每張 PR 記錄：
+   - ecosystem：npm 或 GitHub Actions。
+   - package／group 與 from → to。
+   - security update 或 version update。
+   - direct／transitive、runtime／dev／CI。
+   - SemVer delta：patch／minor／major。
+   - lockfile、manifest、workflow 與 production code 變更範圍。
+   - CI 狀態、merge conflict、blocked peer dependency 與其他 PR 的重疊。
+5. 查詢目標版本的官方 changelog、migration guide、engines／peer requirements 與已知 breaking changes。
+
+可使用唯讀命令：
+
+```bash
+gh pr list --state open --author app/dependabot --json number,title,url,headRefName,baseRefName,createdAt,updatedAt
+gh pr view {PR_NUMBER} --json title,body,labels,files,commits,mergeable,statusCheckRollup
+gh api repos/{OWNER}/{REPO}/dependabot/alerts
+npm audit
+```
+
+GitHub API、registry 或 PR 狀態是即時資料，每次 triage 都重新查詢，不沿用舊對話快取。
+
+## Phase 2：排序與分群
+
+依序套用以下優先級；同級再依 blast radius 由小到大：
+
+| 等級 | 條件 | 預設處置 |
+| --- | --- | --- |
+| P0 | open Critical／High Security Alert、已知可利用 runtime 漏洞 | 立即路由安全修補技能 |
+| P1 | 阻擋 CI/CD、目前 runtime 即將失效、必要相容性基線 | 優先建立獨立修復項目 |
+| P2 | 低風險 patch／minor、lockfile-only、同域 grouped update | 驗證後優先清理 |
+| P3 | test runner、lint、CLI 等非語言基線工具的 major update | 獨立相容性評估後處理 |
+| P4 | runtime、language／compiler、VS Code engine 或無急迫性的高 blast radius major migration | 延後並先做 SDD gate |
+
+排序時另外遵守：
+
+- 先處理其他 PR 的 prerequisite，再處理被依賴者。
+- 不把 npm 與 GitHub Actions 混為同一實作項目。
+- 只在套件、風險、驗證方式與 rollback 邊界相同時分群。
+- grouped PR 若只有單一 dependency 失敗，優先拆出該 dependency；不要讓整組長期阻塞。
+- 多張 PR 更新同一 manifest／lockfile 時，排定序列並預期 Dependabot 重新 rebase 或自動關閉過時 PR。
+
+## Phase 3：SDD Gate
+
+為每個工作項目輸出 `No SDD`、`Lightweight plan` 或 `Full SDD`，並附一句理由。
+
+### No SDD
+
+符合以下全部條件時使用：
+
+- 行為與架構契約不變。
+- 變更侷限於版本、lockfile、Action SHA 或少量相容性設定。
+- 官方 migration 指引清楚，驗收可由現有測試覆蓋。
+- 不改 runtime API、使用者設定、持久化格式或跨 Extension Host／WebView contract。
+
+Language／compiler major（例如 TypeScript major）不得在未讀官方 migration guide 與編譯差異前直接判為 No SDD；至少先做 SDD gate，依實際 blast radius 選 Lightweight plan 或 Full SDD。
+
+### Lightweight plan
+
+用於主要 test／lint／build 工具升級，或涉及多個設定檔但沒有產品設計決策。先列出受影響設定、相容性修正、測試矩陣與 rollback，再實作；不建立完整 spec artifacts。
+
+### Full SDD
+
+符合任一條件時使用：
+
+- 依賴升級迫使產品 runtime 行為、API、資料格式、安全模型或使用者設定改變。
+- 涉及多個架構層或 Extension Host／WebView／generator contract。
+- 有多種遷移方案、重大 breaking change 或不可逆決策。
+- 需大規模程式碼遷移，現有驗收標準不足以界定完成狀態。
+
+先檢查既有 `specs/` 是否已有相符 feature；需要完整 SDD 時依專案順序使用：`$speckit-clarify` → `$speckit-specify` → `$speckit-plan` → `$speckit-tasks` → `$speckit-analyze` → `$speckit-implement` → `$speckit-checklist`。未通過對應 gate 前不得開始依賴實作。
+
+## Phase 4：提交 Triage 報告並停止
+
+輸出固定表格：
+
+| Priority | PR | Update type | Scope | Delta | CI | Dependencies | SDD | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+Recommendation 只能是：
+
+- `merge as-is after validation`
+- `replace with human-owned PR`
+- `split or regroup`
+- `defer`
+- `ignore with documented reason`
+- `close as superseded`
+
+接著列出：
+
+1. 建議處理順序與分群。
+2. 每項必要測試與官方資料來源。
+3. 適合另開新對話的工作項目及 handoff prompt。
+4. 需要使用者決定的 ignore、defer、split、close 或 SDD 選項。
+
+等待使用者核准排序與指定第一個工作項目。Triage 核准不自動授權後續所有 merge 或發布。
+
+## Phase 5：逐項處理
+
+每個獨立工作項目建議使用新對話，並帶入：PR URL、from/to、分類、官方 migration 重點、SDD 決定、驗證清單與已核准處置。不要把整份歷史 triage 原文塞入每個對話。
+
+### Security Update
+
+完整使用 [security-vulnerability-fix](../security-vulnerability-fix/SKILL.md)。由該技能決定修復版本、雙語 CHANGELOG、PATCH release、PR、annotated tag 與 Actions CD。不要在本技能複製或繞過其核准 gate。
+
+### Version Update
+
+1. 從最新且乾淨的 `master` 建立隔離分支／worktree。
+2. 先檢查 Dependabot diff；不得假設 bot 產生的 lockfile 一定正確。
+3. 若可原樣合併，直接在隔離環境驗證該 PR commit，不新增無關變更。
+4. 若需程式碼、設定、測試或多 PR 合併：建立 human-owned branch，重做最小版本更新並加入必要修正；保留原 PR URL 作為追蹤依據。
+5. npm 更新至少驗證：`npm ci`、`npm audit`、`npm ls {PACKAGE}`、`npm run ci:static`、`npm run test:unit:ci`。工具鏈／發布相關更新再執行 `npm run test:release` 與 `npm run release:prepare`。
+6. GitHub Actions 更新必須保留完整 commit SHA pin，核對 upstream tag／SHA，並執行 workflow YAML、release contract 與受影響 CI 驗證。
+7. 使用本地 code review 比較 `origin/master...HEAD`，檢查 regression、breaking changes、lockfile 異常、engine／peer mismatch 與供應鏈風險。
+8. 例行 Version Update 不自動 bump extension 版本或發布。若使用者要求正式發布，再完整使用 [git-workflow](../git-workflow/SKILL.md) 與 [pr-review-release](../pr-review-release/SKILL.md)。
+
+## Phase 6：遠端動作與完成條件
+
+- comment、`@dependabot recreate`、ignore、close、push、建立替代 PR 或 merge 都是遠端 mutation；執行前重述確切 PR 與動作，並確認已在使用者核准範圍內。
+- grouped PR 建置失敗時，可在核准後使用 `@dependabot recreate`；若單一套件持續失敗，調整 `exclude-patterns` 或建立獨立人工 PR。
+- ignore 必須記錄套件、版本範圍、原因、風險、重新評估條件與日期；不得用 ignore 掩蓋 Security Alert。
+- 只在 required checks、review 與 branch rules 全部通過後 merge。
+- merge 後同步 `master`，重新盤點剩餘 PR；確認 Dependabot 是否自動 rebase／關閉 superseded PR，再開始下一項。
+
+每項完成時回報：PR／replacement PR、實際版本、SDD 決定、測試、merge 狀態、剩餘風險，以及下一個佇列項目。不得聲稱整批完成，除非重新 triage 後已無待處理項目。
+
+## 相關資源
+
+- [安全漏洞修補技能](../security-vulnerability-fix/SKILL.md)
+- [Git 工作流程技能](../git-workflow/SKILL.md)
+- [PR Review 與發布技能](../pr-review-release/SKILL.md)
+- [CI/CD 操作手冊](../../../docs/ci-cd.md)
+- [Dependabot 設定](../../dependabot.yml)

--- a/.github/skills/manage-dependabot-prs/agents/openai.yaml
+++ b/.github/skills/manage-dependabot-prs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dependabot PR 管理"
+  short_description: "盤點、排序、評估並逐項處理 Dependabot PR"
+  default_prompt: "使用 $manage-dependabot-prs 盤點目前所有 Dependabot PR，排序優先級並判斷是否需要 SDD，先不要修改或合併。"

--- a/.github/skills/security-vulnerability-fix/SKILL.md
+++ b/.github/skills/security-vulnerability-fix/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: security-vulnerability-fix
-description: 修復 npm 依賴安全漏洞的完整工作流程。當使用者提到安全警告、Dependabot alerts、CVE 漏洞、npm audit 問題時自動啟用。包含查詢漏洞、升級依賴、驗證修復、發布版本的完整流程。Fixes npm dependency security vulnerabilities with a complete workflow including Dependabot alert analysis, package upgrades, build verification, version release following semantic versioning.
+description: 修復 npm 依賴安全漏洞的完整工作流程。當使用者提到安全警告、Dependabot Security Alerts、CVE、GHSA 或 npm audit 漏洞時使用；不適用於沒有安全公告的例行 Dependabot Version Update PR。包含漏洞分析、依賴升級、驗證、PR、annotated tag 與 GitHub Actions CD。Fix npm security vulnerabilities from Dependabot alerts, CVEs, GHSAs, or npm audit findings, then release through the protected-branch and tag-driven CI/CD workflow; do not use for routine version-update PRs without a security advisory.
 metadata:
     author: singular-blockly
-    version: '1.1.0'
+    version: '2.0.0'
     category: security
 ---
 
@@ -18,6 +18,8 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
 - 執行 `npm audit` 發現漏洞
 - 需要升級有 CVE 的套件
 - 發布安全修補版本 (PATCH release)
+
+不要把單純「有較新版本」的 Dependabot Version Update PR 視為安全漏洞。沒有 open Security Alert、CVE／GHSA 或 `npm audit` finding 時，改用一般依賴升級流程，不要自動 bump 專案版本或發布安全修補版。
 
 ## 工作流程 Workflow
 
@@ -47,6 +49,8 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
     npm audit
     ```
 
+    如果 Security Alerts 沒有 open 項目且 `npm audit` 為 0，停止安全修補流程並回報這是一般版本更新。
+
 5. **評估風險**
     - Critical/High: 立即修復
     - Medium: 排程修復
@@ -54,8 +58,8 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
 
 6. **判斷依賴類型**
     - 直接依賴 (direct) → 直接升級 package.json 中的版本
-    - 間接依賴 (transitive) → 使用 `overrides` 欄位強制升級
-    - devDependency → 風險較低但仍應修復，使用 `overrides`
+    - 間接依賴 (transitive) → 先升級最近的直接／上游依賴；只有沒有安全相容版本時才使用精確、最小範圍的 `overrides`
+    - devDependency → 仍需分析實際 build／CI 暴露面；不要只因是開發依賴就忽略漏洞
 
 ### Phase 2: 版本規劃 Version Planning
 
@@ -69,17 +73,23 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
     npm view {package_name} versions --json | tail -5
     ```
 
+3. **提出修復方案並取得核准**
+    - 列出 Alert／CVE／GHSA、嚴重度、受影響依賴路徑與修復版本。
+    - 說明直接升級或 `overrides` 的選擇及相容性風險。
+    - 提出 SemVer、雙語 CHANGELOG 草稿、測試範圍與預定 `vX.Y.Z`。
+    - 未取得修正核准前，不修改 dependency、版本或 CHANGELOG。
+
 ### Phase 3: 實施修復 Implementation
 
-1. **更新 package.json**
-    - 更新專案版本號（PATCH bump）
-    - 直接依賴：修改 `dependencies` / `devDependencies` 中的版本
-    - 間接依賴：在 `overrides` 區塊新增版本覆蓋
+1. **在功能分支更新依賴與版本**
+    - 直接依賴：修改 `dependencies` / `devDependencies` 中的版本。
+    - 間接依賴：只在無法由上游安全版本解決時使用精確、最小範圍的 `overrides`。
+    - 使用 `npm version {VERSION} --no-git-tag-version` 同步更新 `package.json` 與 `package-lock.json`；此時禁止建立 tag。
 
     ```jsonc
     // 間接依賴使用 overrides 範例
     "overrides": {
-        "flatted": ">=3.4.0"
+        "flatted": "3.4.2"
     }
     ```
 
@@ -102,27 +112,24 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
 
     ```bash
     npm install
-    npm audit          # 確認 0 vulnerabilities
-    npm ls {package}   # 確認實際安裝版本已升級
-    npm run package    # 或 npm run build
-    npm run test
+    npm ci
+    npm audit
+    npm ls {package}
+    npm run ci:static
+    npm run test:unit:ci
+    npm run test:release
+    npm run release:prepare
     ```
+
+    目標 Alert／CVE 必須消失，Critical／High finding 必須為 0。若仍有與本次無關且無可用修復的 Medium／Low finding，列出 dependency path、影響與緩解措施，取得使用者明確的殘餘風險核准；不得把有 finding 的結果描述成 `0 vulnerabilities`。
 
 4. **驗證測試失敗為既有問題**（如有測試失敗）
 
-    ```bash
-    # 暫存修改，用原始版本跑測試比對
-    git stash
-    npm test
-    git stash pop
-    ```
+    使用 merge-base／原始 commit 的隔離暫存 worktree 或乾淨 clone，重新執行 `npm ci` 與相同測試。不要用 `git stash`／`stash pop` 搬動使用者工作區，也不要共用修復後的 `node_modules`。只有原始版本在相同環境也失敗，才能判定為既有問題。
 
-    > 若原始版本同樣失敗，確認為既有問題，與本次修改無關。
-
-5. **產生 VSIX** (VS Code 擴充功能專案)
-    ```bash
-    npx @vscode/vsce package
-    ```
+5. **禁止本機正式發布產物**
+    - 不執行本機正式 `vsce package`、`ovsx publish` 或 `vsce publish`。
+    - 不建立準備上傳的正式 VSIX。PR CI 會做 package smoke test；正式發布只使用 GitHub Actions 建置的唯一 artifact。
 
 ### Phase 4: 更新 SECURITY.md Maintenance
 
@@ -159,44 +166,67 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](.
 _Last updated: YYYY-MM-DD_
 ```
 
-### Phase 5: 發布流程 Release Process
+### Phase 5: PR 與 Actions 發布流程 Release Process
 
-> ⚠️ **此階段包含不可逆的遠端操作**。如果是由 AI agent 自動執行，應在使用者明確確認後才進行（除非使用者指示不需要停下來確認）。
+本階段必須同時遵循 [git-workflow](../git-workflow/SKILL.md) 與 [pr-review-release](../pr-review-release/SKILL.md)；後者是發布契約的唯一權威。任何遠端操作前都必須完成其本地 review、修正核准與發布前核准 gate。
 
-1. **Git 提交** (遵循 Conventional Commits)
+1. **在同一功能分支提交完整發布內容**
+
+    `package.json`、`package-lock.json`、雙語 `CHANGELOG.md`、必要的 `SECURITY.md` 與依賴修正必須進入同一 PR。使用 Conventional Commits 與繁體中文描述，例如：
 
     ```bash
     git add package.json package-lock.json CHANGELOG.md SECURITY.md
     git commit -m "chore(deps): 修復 {package} {漏洞類型} ({CVE})"
     ```
 
-2. **建立標籤**
+2. **取得發布核准後建立 PR**
+    - 不得直接 push `master`，也不得在 PR 合併前建立正式 tag。
+    - PR 描述列出 Alert／CVE、修復版本、雙語 CHANGELOG 摘要、`npm audit` 與測試結果。
+    - 等待 `CI Gate`、CodeQL、review 對話與受保護分支條件全部通過。
+    - 只使用 squash merge，並刪除遠端功能分支。
+
+3. **同步 `master` 並驗證版本契約**
 
     ```bash
-    git tag -a v{version} -m "Release v{version} - Security patch for {CVE}"
+    git switch master
+    git fetch origin
+    git merge --ff-only origin/master
+    git status --short
+    git rev-parse HEAD
+    git rev-parse origin/master
+    npm ci
+    npm run release:prepare
     ```
 
-3. **推送至遠端**
+    工作區必須乾淨，且 `HEAD` 必須等於 `origin/master`。不得在合併後補做版本或 CHANGELOG commit。
+
+4. **建立並單獨推送 annotated tag**
 
     ```bash
-    git push origin {branch} --follow-tags
+    git ls-remote --tags origin "refs/tags/v{VERSION}"
+    git tag -a v{VERSION} -m "Release v{VERSION}"
+    git cat-file -t v{VERSION}
+    git push origin v{VERSION}
     ```
 
-4. **建立 GitHub Release** (雙語發布說明)
+    `git cat-file -t` 必須輸出 `tag`。若 tag 已存在就停止；禁止刪除、移動、覆寫或重建正式 tag，也禁止使用 `--follow-tags`。
+
+5. **等待 GitHub Actions CD**
+
+    `.github/workflows/publish.yml` 必須從 annotated tag 建置唯一 VSIX，並把同一 artifact 發布至 GitHub Releases、VS Code Marketplace 與 Open VSX。GitHub Release notes 由同版本雙語 CHANGELOG 區段產生。
 
     ```bash
-    gh release create v{version} --title "{Project} v{version} - 安全修補 / Security Patch" --notes-file release-notes.md {vsix_file}
+    gh run list --workflow publish.yml --branch v{VERSION} --limit 1
+    gh run watch {RUN_ID} --exit-status
+    gh run view {RUN_ID} --json status,conclusion,jobs,url
     ```
 
-5. **清理暫存檔案（必須執行！）**
+    不得執行本機正式打包、全域安裝 `vsce`／`ovsx` 或 `gh release create`。
 
-    ```powershell
-    # 移除 VSIX 安裝包與暫時發布說明
-    Remove-Item -Force release-notes.md -ErrorAction SilentlyContinue
-    Remove-Item -Force *.vsix -ErrorAction SilentlyContinue
-    ```
-
-    > ⚠️ **VSIX 必須清除**：GitHub Release 已附加此檔案，本地保留無意義且容易混淆後續版本。
+6. **依發布契約復原失敗**
+    - 單一發布端失敗時只重跑失敗 jobs，不重建 tag、不重發已成功的發布端。
+    - tag run 在發布前因 workflow 缺陷失敗時，先以新 PR 修正，再從 `master` 手動 dispatch 原 annotated tag。
+    - 上一點的一般 rerun 規則有一個明確例外：市集已成功而 GitHub Release 失敗時，不得 rerun 任何市集 job；使用 `recover-github-release.yml` 與原失敗 run 的同一 artifact，只補 GitHub Release。
 
 ### Phase 6: 驗證修復 Verification
 
@@ -206,24 +236,32 @@ _Last updated: YYYY-MM-DD_
     gh api repos/{owner}/{repo}/dependabot/alerts/{number} --jq '{state: .state, fixed_at: .fixed_at}'
     ```
 
-2. **本地最終確認**
+2. **本地與發布端最終確認**
 
     ```bash
-    npm audit  # 應顯示 found 0 vulnerabilities
+    npm audit
     ```
 
-3. **如果警告未自動關閉** (Dependabot 掃描延遲)
-    - 先確認 package-lock.json 在 GitHub 上版本正確
-    - 手動關閉警告：
-    ```bash
-    gh api repos/{owner}/{repo}/dependabot/alerts/{number} -X PATCH -f state="dismissed" -f dismissed_reason="fix_started" -f dismissed_comment="Upgraded to {version} in commit {sha}. See v{release_version} release."
-    ```
+    - GitHub Release 必須是正確版本，包含版本化 VSIX、`.sha256` 與雙語 notes。
+    - VS Code Marketplace 與 Open VSX 必須顯示同一版本。
+    - 下載 GitHub Release VSIX 與 `.sha256` 並驗證。使用 pinned local `vsce` 與官方 Open VSX checksum endpoint 取得另外兩端的值：
 
-> **經驗提示**：`auto_dismissed` 狀態的 Dependabot 警告在推送修復後通常會自動轉為 `fixed`。
+      ```bash
+      npm exec -- vsce show Singular-Ray.singular-blockly --json
+      curl -fsSL "https://open-vsx.org/api/Singular-Ray/singular-blockly/{VERSION}/file/Singular-Ray.singular-blockly-{VERSION}.sha256"
+      ```
 
-## 雙語發布說明範本 Bilingual Release Notes Template
+      從 Marketplace JSON 讀取最新版的 `Microsoft.VisualStudio.Services.VsixSha256`。三個值都必須等於 Actions 唯一 artifact 的 SHA-256。
 
-參考 [release-notes-template.md](./assets/release-notes-template.md) 建立發布說明。
+3. **如果警告未自動轉為 `fixed`**
+    - 先確認修復後的 `package-lock.json` 已在 default branch，且實際 dependency path 不再落入 vulnerable range。
+    - 等待 Dependabot 重新掃描並再次查詢；掃描延遲不代表修復失敗。
+    - 不得把真實漏洞手動 dismiss 成已處理。只有確認為 false positive、不可觸及程式碼或接受風險，並取得使用者明確核准後，才使用與事實相符的 dismissal reason 與完整註解。
+
+## 雙語內容範本 Bilingual Content Templates
+
+- 使用 [changelog-template.md](./assets/changelog-template.md) 撰寫同一 PR 內的版本 CHANGELOG。
+- [release-notes-template.md](./assets/release-notes-template.md) 只作為內容參考；不得在本機建立正式 release notes 或呼叫 `gh release create`。Actions 會從對應 CHANGELOG 區段產生 GitHub Release notes。
 
 ## 檢查清單 Checklist
 
@@ -232,20 +270,23 @@ _Last updated: YYYY-MM-DD_
 - [ ] 更新 package.json (依賴 + 版本號)
 - [ ] 更新 CHANGELOG.md (雙語格式)
 - [ ] 更新 SECURITY.md (移除已修復漏洞、更新支援版本)
-- [ ] npm install + build + test 通過
-- [ ] 產生 VSIX (如適用)
-- [ ] Git commit 遵循 Conventional Commits
-- [ ] 建立版本標籤
-- [ ] 推送至遠端
-- [ ] 建立 GitHub Release (雙語發布說明)
-- [ ] **本地 VSIX 已移除** (`Remove-Item -Force *.vsix`)
-- [ ] **release-notes.md 已移除** (`Remove-Item -Force release-notes.md`)
+- [ ] 目標漏洞已排除、Critical／High 為 0；任何剩餘 Medium／Low finding 已明確核准
+- [ ] `ci:static`、unit tests、release tests 與 `release:prepare` 通過
+- [ ] 本地 review、修正核准、re-review 與發布前核准完成
+- [ ] 版本、lockfile、雙語 CHANGELOG 與安全修正已進入同一 PR
+- [ ] PR 通過 `CI Gate`、CodeQL 並已 squash merge
+- [ ] annotated tag 已驗證為 `tag` 並單獨推送
+- [ ] Actions 使用唯一 VSIX 完成 GitHub Release、Marketplace 與 Open VSX
+- [ ] 三端版本與 SHA-256 一致；本機未重建正式產物
+- [ ] 失敗時只復原失敗發布端，未刪除或重建 tag
 - [ ] 驗證 Dependabot 警告已關閉 (`state: fixed`)
-- [ ] `npm audit` 顯示 0 vulnerabilities
+- [ ] 最終 `npm audit` 結果已如實回報，未隱藏或誤稱剩餘 finding
 
 ## 相關工具 Related Tools
 
 - `gh api` - GitHub CLI API 操作
 - `npm audit` - 本地漏洞掃描
 - `npm ls` - 查看依賴樹
-- `npx @vscode/vsce package` - VS Code 擴充功能打包
+- `npm run release:prepare` - 驗證 tag 前版本與 CHANGELOG 契約
+- `gh pr` - 建立、檢查與 squash merge PR
+- `gh run` - 監看與復原 GitHub Actions 發布

--- a/.github/skills/security-vulnerability-fix/assets/release-notes-template.md
+++ b/.github/skills/security-vulnerability-fix/assets/release-notes-template.md
@@ -1,5 +1,9 @@
 # 🔒 {Project Name} v{X.Y.Z} - 安全修補 / Security Patch
 
+> 此檔僅供撰寫雙語 CHANGELOG 時參考。正式 GitHub Release notes 由
+> `.github/workflows/publish.yml` 從對應版本的 CHANGELOG 區段產生；不得以本機
+> `release-notes.md` 或 `gh release create` 取代 Actions 發布流程。
+
 ## 安全性修復 Security Fixes
 
 ### 🛡️ 修復 {Package Name} {Vulnerability Type} ({CVE-XXXX-XXXX})


### PR DESCRIPTION
## 變更摘要

- 新增專案限定的 Dependabot PR 盤點、排序、SDD gate 與逐項處理技能
- 將安全漏洞修補技能對齊受保護 master、annotated tag 與 GitHub Actions CD
- 新增 Codex 技能連結、agent metadata，並限制正式產物由 Actions 唯一建置

## 審閱結果

- 本地 Code Review：無 P0–P3 findings
- SDD：不需要（僅流程文件與技能 metadata）
- code-simplifier：不適用（無 TS／JS 變更）

## 驗證

- Node.js 22.16.0 npm ci：通過，0 vulnerabilities
- npm run ci:static：通過
- npm run test:unit:ci：1040 passing，1 existing pending
- npm run release:prepare：通過
- symlink、YAML、相對引用與 diff whitespace：通過

## 發布

本 PR 不修改 extension 版本、不建立 tag，也不觸發正式 Release。