### PR TITLE
chore(deps): 移除未使用的 glob 直接依賴

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
 				"copy-webpack-plugin": "^14.0.0",
 				"eslint": "^9.38.0",
 				"fs-extra": "^11.4.0",
-				"glob": "^11.1.0",
 				"ovsx": "1.1.1",
 				"sinon": "^21.0.0",
 				"ts-loader": "^9.6.2",
@@ -5575,29 +5574,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/glob": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-			"dev": true,
-			"dependencies": {
-				"foreground-child": "^3.3.1",
-				"jackspeak": "^4.1.1",
-				"minimatch": "^10.1.1",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^2.0.0"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -6327,21 +6303,6 @@
 			},
 			"funding": {
 				"url": "https://bevry.me/fund"
-			}
-		},
-		"node_modules/jackspeak": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-			"dev": true,
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/jest-worker": {

--- a/package.json
+++ b/package.json
@@ -278,7 +278,6 @@
 		"copy-webpack-plugin": "^14.0.0",
 		"eslint": "^9.38.0",
 		"fs-extra": "^11.4.0",
-		"glob": "^11.1.0",
 		"ovsx": "1.1.1",
 		"sinon": "^21.0.0",
 		"ts-loader": "^9.6.2",


### PR DESCRIPTION
## 變更摘要 Summary

移除專案未使用的 root `glob` devDependency 與其不再需要的 lockfile 子樹。本 PR 取代 Dependabot PR #112；專案工具仍保留各自管理的 transitive `glob` 版本。

## SDD

- No SDD：不改變 runtime、架構、API、設定或持久化契約。

## 變更內容 Changes

- 從 `package.json` 移除直接依賴 `glob@^11.1.0`
- 以 Node 22.16.0／npm 10.9.2 重建 lockfile
- 未修改 TypeScript、JavaScript、版本或 CHANGELOG

## 驗證 Test Plan

- `npm ci`：通過
- `npm audit --audit-level=high`：0 vulnerabilities
- `npm ls glob --all`：只剩 VS Code test CLI、Mocha 與 vsce 的 transitive 版本
- `npm run ci:static`：通過
- 隔離 `npm run test:unit:ci`：1040 passing、1 pending
- `npm run release:prepare`：通過
- VSIX package smoke test：通過（6.25 MB）
- 本地 code review／security review：無 P0–P3 finding

## 追蹤 Tracking

- Related Dependabot PR: #112
- Merge 後再確認 #112 是否由 Dependabot 自動關閉。