### PR TITLE
fix(webview): 修正 CyberBrick 中文輸入法組字

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [未發布] Unreleased
 
+### 🐛 修復 Bug Fixes
+
+- 修正 Blockly 13 內嵌函式與參數名稱欄位在中文 IME 組字期間，將選字 Enter 誤判為完成編輯；組字按鍵現在會保留給輸入法，後續 Enter 才會提交欄位
+  Fixed Blockly 13 inline function and parameter name fields treating the IME candidate-selection Enter key as edit completion; composition keys now remain with the input method and a later Enter commits the field
+
 ## [0.86.0] - 2026-08-12
 
 ### ✨ 新增功能 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [未發布] Unreleased
 
+## [0.86.1] - 2026-08-13
+
 ### 🐛 修復 Bug Fixes
 
 - 修正 Blockly 13 內嵌函式與參數名稱欄位在中文 IME 組字期間，將選字 Enter 誤判為完成編輯；組字按鍵現在會保留給輸入法，後續 Enter 才會提交欄位

--- a/media/blockly/blocks/functions.js
+++ b/media/blockly/blocks/functions.js
@@ -339,7 +339,13 @@ Blockly.Blocks['arduino_function'] = {
 	init: function () {
 		this.appendDummyInput('MAIN')
 			.appendField(window.languageManager.getMessage('FUNCTION_CREATE'))
-			.appendField(new Blockly.FieldTextInput('myFunction', createCyberBrickNameFieldValidator('function')), 'NAME')
+			.appendField(
+				window.blocklyRuntime.createImeSafeFieldTextInput(
+					'myFunction',
+					createCyberBrickNameFieldValidator('function')
+				),
+				'NAME'
+			)
 			.appendField(':', 'PARAM_LABEL');
 
 		this.appendStatementInput('STACK').setCheck(null);
@@ -658,7 +664,10 @@ Blockly.Blocks['arduino_function_parameter'] = {
 				]),
 				'TYPE'
 			)
-			.appendField(new Blockly.FieldTextInput('x', createCyberBrickNameFieldValidator('parameter')), 'NAME');
+			.appendField(
+				window.blocklyRuntime.createImeSafeFieldTextInput('x', createCyberBrickNameFieldValidator('parameter')),
+				'NAME'
+			);
 		this.setPreviousStatement(true);
 		this.setNextStatement(true);
 		this.setStyle('procedure_blocks'); // 修改這裡，使用主題中定義的顏色

--- a/media/js/blocklyRuntime.js
+++ b/media/js/blocklyRuntime.js
@@ -40,6 +40,29 @@
 		}
 	}
 
+	function isImeCompositionEvent(event) {
+		return Boolean(
+			(event &&
+				(event.isComposing || event.key === 'Process' || event.keyCode === 229 || event.which === 229)) ||
+				(typeof window.isBlocklyTextInputCompositionActive === 'function' &&
+					window.isBlocklyTextInputCompositionActive())
+		);
+	}
+
+	class ImeSafeFieldTextInput extends Blockly.FieldTextInput {
+		onHtmlInputKeyDown_(event) {
+			if (isImeCompositionEvent(event)) {
+				return;
+			}
+			super.onHtmlInputKeyDown_(event);
+		}
+	}
+
+	function createImeSafeFieldTextInput(initialValue, validator) {
+		ensureBlockly();
+		return new ImeSafeFieldTextInput(initialValue, validator);
+	}
+
 	function getWorkspace() {
 		return canonicalWorkspace;
 	}
@@ -490,6 +513,7 @@
 	window.getBlocklyWorkspace = getWorkspace;
 	window.blocklyRuntime = Object.freeze({
 		config,
+		createImeSafeFieldTextInput,
 		createWorkspace,
 		recreateWorkspace,
 		disposeWorkspace,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "singular-blockly",
-	"version": "0.86.0",
+	"version": "0.86.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "singular-blockly",
-			"version": "0.86.0",
+			"version": "0.86.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "singular-blockly",
 	"displayName": "Singular Blockly",
 	"description": "VS Code extension for visual Arduino & MicroPython programming with Blockly. Multi-board support, project-local Agent Skills, AI camera integration, PlatformIO integration, and 15 languages.",
-	"version": "0.86.0",
+	"version": "0.86.1",
 	"license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.109.0",

--- a/scripts/generate-skill-contract.js
+++ b/scripts/generate-skill-contract.js
@@ -129,6 +129,11 @@ function loadRuntime() {
 		getBlocklyWorkspace() {
 			return currentWorkspace;
 		},
+		blocklyRuntime: {
+			createImeSafeFieldTextInput(initialValue, validator) {
+				return new Blockly.FieldTextInput(initialValue, validator);
+			},
+		},
 		languageManager: { getMessage: key => key },
 		addEventListener() {},
 		removeEventListener() {},

--- a/src/test/suite/blocklyImeCompatibility.contract.test.ts
+++ b/src/test/suite/blocklyImeCompatibility.contract.test.ts
@@ -9,14 +9,38 @@ import { describe, it } from 'mocha';
 import { normalizeWhitespace, readWorkspaceFile } from './editorThemeSurfaceContractUtils';
 
 describe('Blockly IME keyboard compatibility contract', () => {
-	it('uses Blockly 13 native text input handling without protected prototype patches', () => {
-		const source = readWorkspaceFile('media/js/blocklyEdit.js');
+	it('uses app-owned IME-safe fields without patching Blockly core prototypes', () => {
+		const editorSource = readWorkspaceFile('media/js/blocklyEdit.js');
+		const runtimeSource = readWorkspaceFile('media/js/blocklyRuntime.js');
+		const functionBlocksSource = readWorkspaceFile('media/blockly/blocks/functions.js');
 
-		assert.ok(!source.includes('installBlocklyTextInputImePatch'), 'WebView must not install a Blockly text-input prototype patch');
-		assert.ok(!source.includes('onHtmlInputKeyDown_'), 'WebView must not access Blockly protected keydown methods');
-		assert.ok(!source.includes('fieldInputPrototype'), 'WebView must not mutate the FieldInput prototype');
-		assert.ok(source.includes("event.key === 'Process'"), 'IME detection should recognize browser Process key events');
-		assert.ok(source.includes('event.keyCode === 229'), 'IME detection should recognize legacy composition keyCode 229 events');
+		assert.ok(
+			!editorSource.includes('installBlocklyTextInputImePatch'),
+			'WebView must not install a Blockly text-input prototype patch'
+		);
+		assert.ok(!editorSource.includes('fieldInputPrototype'), 'WebView must not mutate the FieldInput prototype');
+		assert.ok(
+			runtimeSource.includes('class ImeSafeFieldTextInput extends Blockly.FieldTextInput'),
+			'Runtime should own the IME-safe FieldTextInput subclass'
+		);
+		assert.ok(
+			runtimeSource.includes('createImeSafeFieldTextInput,'),
+			'Runtime should expose the IME-safe field factory'
+		);
+		assert.strictEqual(
+			(functionBlocksSource.match(/window\.blocklyRuntime\.createImeSafeFieldTextInput\(/g) || []).length,
+			2,
+			'Function and parameter name fields should both use the IME-safe factory'
+		);
+		assert.ok(
+			!functionBlocksSource.includes('new Blockly.FieldTextInput'),
+			'Function name fields should not bypass the IME-safe factory'
+		);
+		assert.ok(runtimeSource.includes("event.key === 'Process'"), 'IME detection should recognize browser Process key events');
+		assert.ok(
+			runtimeSource.includes('event.keyCode === 229'),
+			'IME detection should recognize legacy composition keyCode 229 events'
+		);
 	});
 
 	it('bypasses global WebView shortcuts while text inputs or IME composition are active', () => {

--- a/src/test/suite/blocklyV13Locale.contract.test.ts
+++ b/src/test/suite/blocklyV13Locale.contract.test.ts
@@ -52,7 +52,11 @@ suite('Blockly 13 locale contract', () => {
 			addEventListener: (name: string, callback: Function) => listeners.set(name, [...(listeners.get(name) || []), callback]),
 			dispatchEvent: () => true,
 		};
+		class FieldTextInputStub {
+			onHtmlInputKeyDown_() {}
+		}
 		const Blockly = {
+			FieldTextInput: FieldTextInputStub,
 			Msg: { ...localeData.en, PROJECT: 'English project' },
 			inject: () => ({ dispose() {} }),
 			setLocale: (messages: Record<string, string>) => Object.assign(Blockly.Msg, messages),

--- a/src/test/webview/blocklyDialog.contract.test.ts
+++ b/src/test/webview/blocklyDialog.contract.test.ts
@@ -30,7 +30,20 @@ function createRuntimeHarness() {
 			listeners.get(type)?.delete(listener);
 		},
 	};
+	class FieldTextInputStub {
+		readonly delegatedEvents: unknown[] = [];
+
+		constructor(
+			readonly value: unknown,
+			readonly validator?: unknown
+		) {}
+
+		onHtmlInputKeyDown_(event: unknown) {
+			this.delegatedEvents.push(event);
+		}
+	}
 	const blocklyStub: any = {
+		FieldTextInput: FieldTextInputStub,
 		inject: () => ({ dispose() {} }),
 		serialization: { workspaces: { save: () => ({}), load: () => undefined } },
 		dialog: {
@@ -75,6 +88,44 @@ function createRuntimeHarness() {
 		},
 	};
 }
+
+suite('Blockly IME-safe field contract', () => {
+	test('組字按鍵保留給 IME，一般完成編輯按鍵交回 Blockly', () => {
+		const harness = createRuntimeHarness();
+		const validator = () => undefined;
+		const field = harness.windowStub.blocklyRuntime.createImeSafeFieldTextInput('myFunction', validator);
+		let preventDefaultCalls = 0;
+		let stopPropagationCalls = 0;
+
+		field.onHtmlInputKeyDown_({
+			key: 'Enter',
+			isComposing: true,
+			preventDefault: () => preventDefaultCalls++,
+			stopPropagation: () => stopPropagationCalls++,
+		});
+		field.onHtmlInputKeyDown_({ key: 'Process' });
+		field.onHtmlInputKeyDown_({ key: 'Enter', keyCode: 229 });
+		field.onHtmlInputKeyDown_({ key: 'Escape', which: 229 });
+		harness.windowStub.isBlocklyTextInputCompositionActive = () => true;
+		field.onHtmlInputKeyDown_({ key: 'Tab' });
+
+		assert.strictEqual(field.delegatedEvents.length, 0);
+		assert.strictEqual(preventDefaultCalls, 0, 'IME composition must keep its default browser behavior');
+		assert.strictEqual(stopPropagationCalls, 0, 'IME composition must remain available to the browser input method');
+
+		harness.windowStub.isBlocklyTextInputCompositionActive = () => false;
+		for (const key of ['Enter', 'Escape', 'Tab']) {
+			field.onHtmlInputKeyDown_({ key });
+		}
+
+		assert.deepStrictEqual(
+			Array.from(field.delegatedEvents, (event: any) => event.key),
+			['Enter', 'Escape', 'Tab']
+		);
+		assert.strictEqual(field.value, 'myFunction');
+		assert.strictEqual(field.validator, validator);
+	});
+});
 
 suite('Blockly dialog adapter contract', () => {
 	test('prompt 以 request ID 配對取消結果，且重複結果只完成一次', () => {

--- a/src/test/webview/blocklyLegacyFunctionState.contract.test.ts
+++ b/src/test/webview/blocklyLegacyFunctionState.contract.test.ts
@@ -42,7 +42,11 @@ function createRuntimeHarness() {
 		addEventListener() {},
 		removeEventListener() {},
 	};
+	class FieldTextInputStub {
+		onHtmlInputKeyDown_() {}
+	}
 	const blocklyStub: any = {
+		FieldTextInput: FieldTextInputStub,
 		inject() {
 			return { dispose() {} };
 		},


### PR DESCRIPTION
## 變更摘要 Summary

修正 Blockly 13 內嵌函式與參數名稱欄位在中文 IME 組字期間，將選字 Enter 誤判為完成編輯的回歸。
Fixes the Blockly 13 regression where IME candidate-selection Enter prematurely closed inline function and parameter name fields.

## 相關 Spec Related Spec

- Spec 064: `specs/064-cyberbrick-naming-ota-progress/`
- Spec 065: `specs/065-blockly-v13-modernization/`
- 本次為既有契約回歸修復，未新增 SDD feature。

## 變更類型 Type of Change

- [x] 🐛 Bug 修復
- [ ] ✨ 新功能
- [ ] 💥 破壞性變更
- [ ] 📝 文件更新

## 變更內容 Changes

- 新增 app-owned IME-safe `FieldTextInput` subclass／factory，不修改 Blockly core prototype。
- 函式與參數名稱欄位在 composition 期間保留 Enter、Escape、Tab 給輸入法。
- 保留既有 CyberBrick 名稱驗證、warning、重名檢查、序列化與上傳 guard。
- 增加 composition 行為、runtime、legacy、locale 與 Skill contract 回歸測試。

## 測試計劃 Test Plan

- [x] `npm run release:prepare`
- [x] `npm run ci:static`
- [x] `npm run test:unit:ci` — 1084 passing, 1 pending, 0 failing
- [x] 相關契約測試 — 33 passing
- [x] macOS 中文輸入法人工驗證

## 發布資訊 Release Metadata

- Version: `v0.86.1`
- [x] `package.json`、`package-lock.json` 與雙語 CHANGELOG 已包含在本 PR
- 發布將由 annotated `v0.86.1` tag 觸發 GitHub Actions CD。