### PR TITLE
fix(ci): 修正 v0.87.0 不可變標籤發布復原

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
     with:
+      candidate_ref: ${{ inputs.release_tag || github.ref_name }}
       release_candidate: true
 
   quality:

--- a/.github/workflows/runtime-installation.yml
+++ b/.github/workflows/runtime-installation.yml
@@ -12,6 +12,10 @@ on:
         type: boolean
   workflow_call:
     inputs:
+      candidate_ref:
+        description: Immutable release ref selected by the caller
+        required: false
+        type: string
       release_candidate:
         required: false
         default: true
@@ -28,7 +32,7 @@ jobs:
   prepare:
     name: Prepare bound candidate
     if: >-
-      github.event_name == 'workflow_call' ||
+      inputs.release_candidate == true ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'runtime-e2e-approved') ||
       contains(github.event.pull_request.labels.*.name, 'release-candidate')
@@ -44,13 +48,12 @@ jobs:
       - name: Checkout the exact candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.candidate_ref || github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.16.0
-          cache: npm
 
       - name: Install dependencies and package one shared VSIX
         run: |
@@ -105,13 +108,12 @@ jobs:
       - name: Checkout the exact candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.candidate_ref || github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.16.0
-          cache: npm
 
       - name: Download bound candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -176,13 +178,12 @@ jobs:
       - name: Checkout the exact candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.candidate_ref || github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node.js 22.16.0
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.16.0
-          cache: npm
 
       - name: Download bound candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -243,7 +244,7 @@ jobs:
       - name: Checkout evidence verifier
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.candidate_ref || github.event.pull_request.head.sha || github.sha }}
 
       - name: Download evidence files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/scripts/release/prepare-release.test.js
+++ b/scripts/release/prepare-release.test.js
@@ -125,10 +125,26 @@ describe('release preparation', () => {
 
 describe('publish workflow retry contract', () => {
 	const workflow = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'workflows', 'publish.yml'), 'utf8');
+	const runtimeWorkflow = fs.readFileSync(
+		path.join(__dirname, '..', '..', '.github', 'workflows', 'runtime-installation.yml'),
+		'utf8'
+	);
 
 	it('supports recovery from an existing immutable annotated tag', () => {
 		assert.match(workflow, /workflow_dispatch:[\s\S]*?release_tag:/);
 		assert.match(workflow, /release_tag: \$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
+	});
+
+	it('binds the runtime matrix to the same immutable release tag', () => {
+		assert.match(workflow, /candidate_ref: \$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/);
+		assert.match(runtimeWorkflow, /inputs\.release_candidate == true/);
+		assert.ok(!runtimeWorkflow.includes("github.event_name == 'workflow_call'"));
+		assert.ok(!runtimeWorkflow.includes('cache: npm'));
+		const candidateRefs =
+			runtimeWorkflow.match(
+				/ref: \$\{\{ inputs\.candidate_ref \|\| github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/gu
+			) || [];
+		assert.strictEqual(candidateRefs.length, 4);
 	});
 
 	it('keeps first marketplace attempts strict', () => {

--- a/specs/067-managed-platformio-environment/checklists/implementation.md
+++ b/specs/067-managed-platformio-environment/checklists/implementation.md
@@ -59,20 +59,30 @@
 - [x] 一般資料夾取消路徑證明 `ProjectSkillService.ensureInstalled()` 與 `SettingsManager.configurePlatformIOSettings()` 呼叫次數皆為 0；缺少設定檔的唯讀查詢不建立 `.vscode/`。
 - [x] 依 F5 再現結果移除 activation 與 workspace-folder change 的背景 Skill 安裝入口，並合併並行 editor-open；隔離 VS Code 1.109 重新執行 activation、settings 與 WebView manager 共 99 項通過，包含既有 Blockly folder 在 activation 時也不安裝、取消前不建立 panel／settings／Skill，以及兩個並行開啟只呼叫一次 safety flow。
 - [x] OTA 契約證明設定與清除共用單一進度 DOM，兩者都在 Host request 前顯示；設定採實際里程碑、清除 running 省略 `aria-valuenow`，CSS 不再引用未定義的 `--button-primary-bg`。
-- [ ] 依 [quickstart.md](../quickstart.md) 步驟 9－12 完成實際 F5 視覺檢查（亮／暗／高對比／reduced-motion）與任意資料夾操作前後檔案樹比對。
+- [x] 依 [quickstart.md](../quickstart.md) 步驟 9－12 完成實際 F5 視覺檢查（亮／暗／高對比／reduced-motion）與任意資料夾操作前後檔案樹比對。
 
-## 合併與發布前尚待完成
+## PR #126 合併與發布閘門結果
 
 - [x] PR #126 首輪 CI 的三 OS unit、static/security、VSIX smoke 與 CodeQL 三語言分析通過；x64 三 OS 與 ARM64 三 OS 的真實安裝／離線重啟也全部通過，其中 Windows ARM64 為 9 分 20 秒。
 - [x] PR #126 首輪總體 CodeQL 以 5 個同源 high annotations 阻擋跨 job output SHA 驅動的 checkout；下游 executable checkout 已改為 GitHub event immutable SHA，prepare output SHA 僅保留作 evidence 身分驗證。
 - [x] 首輪 managed runtime 最終 gate 揭露複數 `--evidence` 參數集合未初始化；parser 回歸測試已加入，並下載該 run 的六份真實 evidence 在本機重播 release verifier，六個 OS／arch 身分全部通過。
 - [x] Phase 14 修正後的 `npm run ci:static`、`npm run release:prepare`、`git diff --check`、workflow trust-boundary 安全掃描與完整有效差異 Code Review 均通過；本輪結論為 `CLEAR`。
-- [ ] PR #126 新 HEAD 必須重新通過總體 CodeQL、CI 與完整 x64／ARM64 runtime evidence gate；首輪結果不能替代修正後 commit 的正式證據。
-- [ ] 在 GitHub PR 執行三 OS x64 真實安裝矩陣，蒐集與 PR head／tree／VSIX／manifest 綁定的 evidence。
-- [ ] 對 release candidate 執行 Linux、Windows、macOS ARM64 矩陣；本機 macOS ARM64 結果只提供先期證據，不取代正式 workflow。
-- [ ] 在乾淨 Windows 與 Linux 帳號手動確認 Extension 啟用、活動列 editor-open 重查、權限錯誤訊息與離線重啟 UX。
-- [ ] 發布候選以實體 Arduino 與 CyberBrick 各完成一次 build／upload／monitor smoke；cloud runner 不連接硬體。
+- [x] PR #126 新 HEAD 重新通過總體 CodeQL、CI 與完整 x64／ARM64 runtime evidence gate；首輪結果未替代修正後 commit 的正式證據。
+- [x] 在 GitHub PR 執行三 OS x64 真實安裝矩陣，蒐集與 PR head／tree／VSIX／manifest 綁定的 evidence。
+- [x] 對 release candidate 執行 Linux、Windows、macOS ARM64 矩陣；正式 workflow 證據已取代本機 macOS ARM64 先期證據。
+- [x] 在乾淨 Windows 與 Linux 帳號手動確認 Extension 啟用、活動列 editor-open 重查、權限錯誤訊息與離線重啟 UX。
+- [x] 發布候選以實體 Arduino 與 CyberBrick 各完成一次 build／upload／monitor smoke；cloud runner 不連接硬體。
+
+## v0.87.0 immutable tag 發布復原
+
+- [x] PR #126 已在 18 項遠端 checks、F5、乾淨 Windows／Linux 與 Arduino／CyberBrick 實機閘門通過後 squash merge；annotated `v0.87.0` 精確指向 merge commit `43948d49fce58fcfb9f4c34b703ce2b686c7cd99`，且 squash tree 與已測 PR tree 相同。
+- [x] 首次 tag push run `31981704124` 在所有發布 job 開始前失敗；GitHub Release、VS Code Marketplace 與 Open VSX 均為 skipped，tag 不得刪除、移動或重建。
+- [x] 根因為 reusable runtime workflow 的 `github.event_name` 沿用 tag caller 的 `push`，不會變成 `workflow_call`；原 prepare 條件因此錯誤跳過。Recovery 另須把同一 release tag 綁定至 runtime checkout，避免驗證修復後 master 而非發布內容。
+- [x] Recovery 本地 `npm run ci:static`、23 項 release contract、`release:prepare`、YAML parse、`git diff --check` 與連線 `npm audit`（0 vulnerabilities）通過；`code-simplifier` 與完整差異 review 在移除動態 ref 的 npm cache 後為 `CLEAR`。
+- [x] 本機 VS Code 1.109 unit launcher 在 macOS 26 仍於測試案例前以既知 `SIGABRT` 結束；未把它誤記為案例通過，正式 unit 證據由 recovery PR 的乾淨 runner 提供。
+- [ ] Recovery 修正 PR 必須通過乾淨 runner unit、CI、CodeQL 與必要 runtime matrix；合併後只能從 `master` dispatch 同一 immutable `v0.87.0`。
+- [ ] Recovery publish run 必須重新驗證 annotated tag、release tree、唯一 VSIX 與 checksum，並確認 GitHub Release、VS Code Marketplace、Open VSX 三端成功。
 
 ## 結論
 
-本機可完成的程式、封裝、真實 macOS ARM64 runtime、安全、本地 Code Review 與 `0.87.0` 發布契約均已通過。T061 保持未完成，直到 F5 視覺驗收、PR 遠端矩陣、乾淨 macOS runner 與發布前實機 smoke 取得證據；這些是既定 release gates，不是尚未實作的產品程式碼。
+本機程式、封裝、安全與 Code Review，以及 F5、PR 六平台 runtime、乾淨 Windows／Linux 與 Arduino／CyberBrick 實機閘門均已通過，T061 已完成。剩餘工作僅限 recovery 修正 PR 與同一 immutable `v0.87.0` 的三端發布驗證。

--- a/specs/067-managed-platformio-environment/checklists/security.md
+++ b/specs/067-managed-platformio-environment/checklists/security.md
@@ -43,7 +43,7 @@
 
 - [x] logs、診斷、clipboard 與 issue draft 遮蔽 home／workspace、proxy credentials、token-like secrets 與敏感 URL；managed storage 對 WebView 與可分享輸出只提供穩定摘要。顯示實際 managed root 時，WebView 只送固定 command，由 Extension Host 直接呼叫本機檔案管理員，不回傳或記錄完整路徑。
 - [x] evidence 只記錄 OS／arch、runner、path case 名稱、PR／event、head／tree、VSIX／manifest／artifact SHA 與結果，不保存原始使用者路徑或環境變數。
-- [x] workflows 使用最小 `contents: read` 權限、SHA-pinned actions，未使用 `pull_request_target`；具網路與執行未信任程式碼的真實矩陣需由 label／release gate 核准。可執行 checkout 直接綁定 GitHub event immutable SHA，跨 job 輸出的 candidate SHA 僅能用於 evidence 比對，不能決定後續執行內容。
+- [x] workflows 使用最小 `contents: read` 權限、SHA-pinned actions，未使用 `pull_request_target`；具網路與執行未信任程式碼的真實矩陣需由 label／release gate 核准。可執行 checkout 直接綁定 GitHub event immutable SHA；reusable release workflow 必須由 caller 傳入同一 annotated release tag 作 `candidate_ref`，runtime 矩陣不使用 npm dependency cache。跨 job 輸出的 candidate SHA 僅能用於 evidence 比對，不能決定後續執行內容。
 - [x] evidence verifier 拒絕錯誤 PR／event、過期 commit／tree、不同 VSIX／manifest／artifact、缺少或重複平台與未完成 path/offline cases。
 - [x] `npm audit --omit=dev --audit-level=high` 回報正式依賴 0 個已知漏洞；新增的 runtime dependencies 固定為 `@vscode/proxy-agent@0.44.0` 與 `tar@7.5.22`，分別承接 VS Code proxy 設定與受控 archive 解析。
 

--- a/specs/067-managed-platformio-environment/plan.md
+++ b/specs/067-managed-platformio-environment/plan.md
@@ -181,7 +181,7 @@ scripts/
 ### 7. CI、PR 與發布閘門
 
 - `ci.yml` 的每個 PR 在 Windows／macOS／Linux 以本機 fake artifact 執行安裝、Unicode／空白／特殊字元／長路徑、checksum、permission 與 rollback 測試，不連外，維持 `pull_request`、`contents: read`、零 secrets。
-- `runtime-installation.yml` 只由 `pull_request` 的 label gate 或受限 `workflow_dispatch` 執行。`runtime-e2e-approved` 執行三 OS x64 真實下載；`release-candidate` 加入目前宣告支援且可由標準 GitHub-hosted runner 執行的 ARM64。外部 PR 在維護者核准前不執行真實下載，且永不使用 `pull_request_target` 執行 PR 程式碼。所有會執行候選程式碼的 checkout 直接使用 GitHub event 綁定的 immutable SHA；prepare job 輸出的 SHA 只供 evidence 身分比對，不得再作為可執行 checkout ref。
+- `runtime-installation.yml` 只由 `pull_request` 的 label gate 或受限 `workflow_dispatch` 執行。`runtime-e2e-approved` 執行三 OS x64 真實下載；`release-candidate` 加入目前宣告支援且可由標準 GitHub-hosted runner 執行的 ARM64。外部 PR 在維護者核准前不執行真實下載，且永不使用 `pull_request_target` 執行 PR 程式碼。所有會執行候選程式碼的 checkout 直接使用 GitHub event 綁定的 immutable SHA；reusable publish caller 則明確傳入同一 release tag 作 `candidate_ref`，且動態 release ref 的真實矩陣不寫入 npm dependency cache。被呼叫 workflow 的 `github.event_name` 沿用 caller event，不能以 `workflow_call` 字串判斷是否執行；prepare job 輸出的 SHA 只供 evidence 身分比對，不得再作為可執行 checkout ref。
 - 底層 artifact selector 對 `release-candidate` 預設 fail closed；正式 Extension factory 因 publish workflow 強制要求完整 ARM64 release matrix，才明確啟用 manifest 內的 ARM64 候選。缺少對應 evidence 時不得發布該 factory policy。
 - evidence JSON 直接讀取真實 E2E result，記錄 PR／event、head SHA、tree SHA、VSIX SHA-256、runtime manifest SHA-256、runner image／arch、artifact id／SHA-256 與測試結果；verifier 必須將 artifact 逐項對回 manifest。新 commit 使 check 與 evidence 自動失效。
 - squash merge 後的 release 準備腳本比較 master tree 與 evidence 的已測 tree；只有內容相同才允許 annotated tag。tag 工作流重新建置正式 VSIX並執行不連外的封裝資源／fake-runtime smoke，成功後才讓 GitHub Release、Marketplace 與 Open VSX jobs 開始。

--- a/specs/067-managed-platformio-environment/tasks.md
+++ b/specs/067-managed-platformio-environment/tasks.md
@@ -154,7 +154,7 @@
 - [x] T058 [P] 更新 PlatformIO／MicroPython 架構與使用者操作文件於 `docs/specifications/01-architecture/architecture.md`、`docs/specifications/06-features/platformio-diagnostics.md` 與 `docs/specifications/03-hardware-support/cyberbrick-micropython.md`
 - [x] T059 [P] 更新測試覆蓋說明與雙語 CHANGELOG 未發布段落於 `docs/specifications/04-quality-testing/test-coverage.md` 與 `CHANGELOG*.md`
 - [x] T060 執行 `npm run validate:i18n`、`npm run check:project-skills`、compile、lint、unit、integration、package 與 VSIX 資源檢查並修正所有失敗
-- [ ] T061 依 `specs/067-managed-platformio-environment/quickstart.md` 完成決定性、手動與可用平台驗證並記錄結果於 `specs/067-managed-platformio-environment/checklists/implementation.md`
+- [x] T061 依 `specs/067-managed-platformio-environment/quickstart.md` 完成決定性、手動與可用平台驗證並記錄結果於 `specs/067-managed-platformio-environment/checklists/implementation.md`
 - [x] T062 執行安全審查，確認下載、archive、路徑、子程序、log、cleanup 與 workflow trust boundary 於 `specs/067-managed-platformio-environment/checklists/security.md`
 
 ---
@@ -216,6 +216,18 @@
 
 ---
 
+## Phase 15：v0.87.0 immutable tag 發布復原
+
+**目的**：修正首次 tag push 在所有發布端開始前揭露的 reusable caller-event 語意與 recovery tag 綁定缺口，保留既有 annotated tag 與 release commit 不變。
+
+- [x] T085 [P] 以 `inputs.release_candidate` 啟動 reusable prepare，新增 caller 提供的 `candidate_ref`，讓 prepare、x64、ARM64 與 evidence gate 都 checkout 同一 release tag，並移除動態 ref 矩陣的 npm dependency cache 於 `.github/workflows/runtime-installation.yml` 與 `.github/workflows/publish.yml`
+- [x] T086 [P] 新增 caller event 不得假設為 `workflow_call`、publish／runtime 必須共用 release tag、四個 executable checkout ref 及 runtime 不得寫入 npm cache 的回歸契約於 `scripts/release/prepare-release.test.js`
+- [x] T087 重跑 release／靜態／安全測試、code-simplifier 與完整本地 Code Review，更新 recovery SDD 證據於 `specs/067-managed-platformio-environment/checklists/implementation.md`
+- [ ] T088 建立 recovery 修正 PR，通過乾淨 runner unit、CI、CodeQL 與必要 runtime matrix後 squash merge
+- [ ] T089 從 `master` dispatch 同一 annotated `v0.87.0`，驗證 runtime、唯一 VSIX、checksum 與三個發布端，不刪除或重建 tag
+
+---
+
 ## 相依與執行順序
 
 ### 階段相依
@@ -225,7 +237,7 @@
 - US1 → US2：CoreEnvironmentManager 需要可用的 managed provider。
 - US2 → US5／US4：provider 相容與診斷需要完成雙 Core 路由。
 - US3 可在 US1 完成後與 US2 並行；US6 可在 Phase 2 後先做 evidence 工具，但 workflow 完整驗證依 US1／US3。
-- Phase 9 依所有納入發布的故事完成；Phase 10 是 F5 驗收回饋的收斂增量；Phase 11 重新審查完整有效差異；Phase 12 完成本地發布契約；Phase 13 再驗證已提交分支的零寫入與 fallback authority；Phase 14 收斂 PR 首輪遠端安全與證據閘門 finding，這些階段都不解除 T061 的遠端矩陣與實機發布閘門。
+- Phase 9 依所有納入發布的故事完成；Phase 10 是 F5 驗收回饋的收斂增量；Phase 11 重新審查完整有效差異；Phase 12 完成本地發布契約；Phase 13 再驗證已提交分支的零寫入與 fallback authority；Phase 14 收斂 PR 首輪遠端安全與證據閘門 finding；Phase 15 只修復既有 immutable tag 的 workflow recovery，不改變 `v0.87.0` release tree。
 - US7 的同意 gate 先於任何 workspace-local Skill／設定寫入；US8 與 managed runtime 安裝彼此獨立，可在 US7 測試完成後平行驗證。
 
 ### 平行機會
@@ -256,8 +268,8 @@
 7. Phase 9：全域驗證與文件。
 8. Phase 10：依 F5 回饋加固使用者同意邊界與 OTA 共用進度。
 9. Phase 11：以完整工作樹反覆 review／fix／verify，直到沒有可採納 finding。
-10. Phase 12－14：完成 `0.87.0` 本地發布契約，對已提交完整差異執行安全重審，並收斂 PR 遠端 CodeQL／evidence finding。
+10. Phase 12－15：完成 `0.87.0` 本地發布契約，對已提交完整差異執行安全重審，收斂 PR 遠端 CodeQL／evidence finding，並以新 PR 修復不可變 tag 的發布 workflow。
 
 ## 任務格式驗證
 
-全部 86 個任務（含 T024A／T024B）皆使用 `- [ ] Txxx [P?] [US?] 描述＋明確檔案路徑`；Setup、Foundational 與收斂任務不含故事標籤，故事階段皆含對應 `[USn]`。T061 保持未完成，直到遠端矩陣與實機 smoke 取得正式證據。
+全部 91 個任務（含 T024A／T024B）皆使用 `- [ ] Txxx [P?] [US?] 描述＋明確檔案路徑`；Setup、Foundational 與收斂任務不含故事標籤，故事階段皆含對應 `[USn]`。T061 已由遠端矩陣、F5、乾淨 OS 與實機 smoke 正式證據完成；T088 保持未完成直到 recovery PR 完成，T089 保持未完成直到同一 `v0.87.0` recovery publish run 驗證三個發布端。


### PR DESCRIPTION
## 摘要
- 修正 reusable runtime workflow 沿用 caller event，導致 tag push prepare 被跳過的問題
- 將 publish recovery 的 release tag 傳入 runtime matrix，四個 executable checkout 使用同一不可變標籤
- 移除動態 release ref 的 npm dependency cache，降低 cache poisoning 風險
- 更新 spec 067 的 plan、tasks、安全與發布復原驗證紀錄

## 驗證
- npm run ci:static
- npm run test:release（23 passing）
- npm run release:prepare
- npm audit --audit-level=high（0 vulnerabilities）
- workflow YAML parse
- git diff --check
- local Code Review：CLEAR

## 發布邊界
- 既有 annotated v0.87.0 tag object 保持不變
- 首次 publish run 31981704124 未開始任何發布端
- 本 PR 通過 CI、CodeQL 與完整 x64／ARM64 runtime matrix 後才 squash merge
- 合併後由 master dispatch 同一 v0.87.0，不刪除、移動或重建 tag