### PR TITLE
fix(runtime): 修正 Windows 受管 Core 安裝與診斷

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.87.1] - 2026-08-17
+
+### 🐛 修復 Bug Fixes
+
+- 修正 Windows 預設 Extension 儲存位置可能因過長的 immutable runtime 目錄而使 Singular managed Core 安裝失敗；新安裝改用短版交易識別目錄，既有健康安裝仍保持相容
+  Fixed Singular managed Core installations potentially failing under the default Windows extension storage because of an overlong immutable runtime directory; new installations use a short transaction identifier while existing healthy installations remain compatible
+- 保留經隱私遮蔽的 managed installer 階段、exit code、stdout 與 stderr，並在診斷、AI repair packet 與 issue draft 顯示背景安裝中或最近失敗狀態，不再錯誤回報沒有 blocker
+  Preserved privacy-redacted managed installer stage, exit code, stdout, and stderr, and exposed active or recently failed background provisioning in diagnostics, AI repair packets, and issue drafts instead of incorrectly reporting no blocker
+- managed provisioning 在工作負載啟動前失敗時，允許 CyberBrick 安全使用健康的 PlatformIO provider 作為單次 fallback；取消及已啟動的專案或上傳程序仍維持禁止 fallback
+  Allowed CyberBrick to use a healthy PlatformIO provider as a one-time fallback when managed provisioning fails before the workload starts, while cancellation and already-started project or upload processes remain fail-closed
+
 ## [0.87.0] - 2026-08-17
 
 ### ✨ 新增功能 Features

--- a/docs/specifications/01-architecture/architecture.md
+++ b/docs/specifications/01-architecture/architecture.md
@@ -123,7 +123,7 @@ Extension Host (Node.js)           WebView (Browser Context)
 
 Extension 的 `onStartupFinished` activation 完成後，`ManagedRuntimeInitializationCoordinator` 先讀取本機 `current.json`；缺失或損壞時在背景呼叫冪等 `ensureReady()`，不等待第一次上傳。使用者每次從活動列或命令開啟 Blockly 編輯器都會再次檢查；同視窗共用單一 in-flight Promise，跨視窗由 install lock 序列化。背景網路失敗不阻止編輯器開啟，上傳器仍自行 `ensureReady()` 作最後防線。
 
-受管理環境位於 Extension `globalStorageUri` 或經驗證的 machine-scoped 本機路徑。根目錄必須為空目錄或已有有效 Singular ownership marker；安裝、修復與 cleanup 共用同一把跨視窗 lock。系統使用固定 SHA-256 manifest 下載 CPython 與 PlatformIO installer，以 pip constraint 限制 PlatformIO 受測版本範圍，完成 staging transaction、工具 probe 與原子 `current.json` 後才視為 ready。它不使用系統 Python，也不修改 provider penv。
+受管理環境位於 Extension `globalStorageUri` 或經驗證的 machine-scoped 本機路徑。根目錄必須為空目錄或已有有效 Singular ownership marker；安裝、修復與 cleanup 共用同一把跨視窗 lock。系統使用固定 SHA-256 manifest 下載 CPython 與 PlatformIO installer，以 pip constraint 限制 PlatformIO 受測版本範圍；`versions/` 下的新候選以固定長度 transaction UUID 命名，完整 runtime／artifact 身分留在 record，為 Windows 預設 global storage 保留路徑預算。完成 staging transaction、工具 probe 與原子 `current.json` 後才視為 ready。它不使用系統 Python，也不修改 provider penv。
 
 工作負載路由固定如下：
 
@@ -132,7 +132,7 @@ Extension 的 `onStartupFinished` activation 完成後，`ManagedRuntimeInitiali
 | Arduino build／upload／monitor | PlatformIO／PIOArduino Provider Core | Singular managed Core |
 | CyberBrick USB／Python／mpremote | Singular managed Core | Provider Core |
 
-只有找不到 executable、spawn、Python import、權限或本機 store 損壞等「專案程序啟動前」錯誤可 fallback 一次。編譯、project config、DNS、proxy、TLS、registry、裝置、serial、取消或 upload spawn 後錯誤都不換 Core。
+只有找不到 executable、spawn、Python import、權限、本機 store 損壞，或 probe／prepare 階段的 managed provisioning 失敗，可在專案程序啟動前 fallback 一次。編譯、project config、DNS、proxy、TLS、registry、裝置、serial、取消或 upload spawn 後錯誤都不換 Core。
 
 ## 編輯器開啟與 Workspace 寫入授權
 

--- a/docs/specifications/04-quality-testing/managed-runtime-environment.md
+++ b/docs/specifications/04-quality-testing/managed-runtime-environment.md
@@ -33,6 +33,8 @@ npm run test:managed-runtime:e2e -- --allow-network
 ARM64 release-candidate artifact 另需 `--allow-release-candidate`。腳本將 runtime 放在自己建立的暫存子目錄；完成後只刪除該子目錄，不接受把 workspace、home 或磁碟根目錄當作清理目標。
 正式 Extension factory 會啟用 manifest 已宣告的 ARM64 release-candidate artifact；這個產品政策的前提是發布 workflow 把對應 ARM64 矩陣設為必要門檻。底層 service 與本機腳本仍預設 fail closed，需明確 flag 才能選取候選 artifact。
 
+真實 E2E 的 sandbox 上層名稱包含 Unicode、空白與合法特殊字元，managed root 再置於 `AppData/Roaming/Code/User/globalStorage/Singular-Ray.singular-blockly/runtime-v1` 等同形狀下；各 OS 都使用同一形狀，Windows 特別用來驗證正式預設路徑預算。evidence 的 path cases 必須包含 `default-global-storage-shape`，不可用較短暫存根替代。
+
 自訂 managed path 只能是空的本機目錄，或先前已有有效 Singular root ownership marker 的目錄；非空且未受管的位置會在建立任何 runtime 子目錄前拒絕。cleanup 與 install 共用 lock，因此安裝進行中的 staging 不會被同時清理。
 
 ## Evidence 契約

--- a/docs/specifications/06-features/platformio-diagnostics.md
+++ b/docs/specifications/06-features/platformio-diagnostics.md
@@ -6,7 +6,7 @@
 
 命令 `singular-blockly.checkPlatformioStatus` 開啟獨立、單例的 WebView 面板，不需先執行上傳。診斷必須重用既有 executable resolver 與 uploader 的解析語意，不另建互相矛盾的路徑偵測器。
 
-面板依固定順序檢查 provider 的 `pio`、`penvRoot`、Python、pip、mpremote，並另顯示 Provider Core 與 Singular managed Core 兩個環境區段。每個 Core 包含 healthy／degraded／unavailable、版本、package 狀態、原因與隱私化 storage 摘要；Arduino／Python 路由另外顯示 primary、fallback、目前選擇及是否已 fallback。工具單項仍包含 `ok`／`warning`／`error`、解析路徑與來源、原因、建議步驟及版本資訊。
+面板依固定順序檢查 provider 的 `pio`、`penvRoot`、Python、pip、mpremote，並另顯示 Provider Core 與 Singular managed Core 兩個環境區段。每個 Core 包含 healthy／degraded／unavailable、版本、package 狀態、原因與隱私化 storage 摘要；managed Core 卡片另以既有安全轉義的 detail 區塊顯示最近 provisioning 的 running／failed attempt、trigger、stage、percent、code 與有界 installer evidence。Arduino／Python 路由另外顯示 primary、fallback、目前選擇及是否已 fallback。工具單項仍包含 `ok`／`warning`／`error`、解析路徑與來源、原因、建議步驟及版本資訊。
 
 UI 狀態為 loading、ready、error，固定提供摘要、雙 Core、工具狀態與檢查範圍說明。診斷只呼叫本機 `getStatus()` 與版本 probe，不啟動 managed runtime 安裝、不做 package 網路探測；尚未真實準備的 package 狀態保持 `unknown`。它也不保證 USB、裝置權限或硬體連線正常。
 
@@ -28,6 +28,6 @@ UI 狀態為 loading、ready、error，固定提供摘要、雙 Core、工具狀
 
 修復歷史保存在 workspace state，最多 20 筆，並以環境 fingerprint 判定 current、stale 或 unknown。歷史與 fingerprint 只保存必要摘要及雜湊，不保存密碼、token 或原始敏感值。
 
-提供 AI 協助時，只建立經隱私清理的結構化 packet，包含 findings、修復歷史及任務描述，不直接附上未處理的 raw logs。Issue draft 也只能在去重與隱私檢查後產生，必須由使用者審閱並主動發布，絕不自動送出。
+提供 AI 協助時，只建立經隱私清理的結構化 packet，包含 findings、修復歷史及任務描述。managed installer stdout／stderr 只有在先遮蔽 home、workspace、managed root、credentials 與 token，移除控制字元並限制長度後才能加入；未處理 raw logs 不得流入 packet。即使 provider operational，最近 managed provisioning running／failed 仍是目前 blocker，不得被摘要成「No current blocker」。Issue draft 也只能在去重與隱私檢查後產生，必須由使用者審閱並主動發布，絕不自動送出。
 
 WebView 只接收可序列化的安全狀態；所有訊息仍由 Extension Host 驗證。核心資料模型包含 DiagnosticFinding、RepairFlow、RepairStep、AutoRepairRun、RepairStepResult、EnvironmentFingerprint、RepairHistorySnapshot、AIRepairPacket、IssueDraftProposal 與 PanelRepairState。

--- a/media/js/platformioDiagnostic.js
+++ b/media/js/platformioDiagnostic.js
@@ -266,6 +266,7 @@ function renderCoreEnvironments(coreDiagnostics) {
 					<div><dt>${escapeHtml(state.strings.storageUsageLabel)}</dt><dd>${escapeHtml(formatBytes(environment.storageUsageBytes))}</dd></div>
 				</dl>
 				${renderDetailBlock(state.strings.reasonLabel, environment.reason || '—')}
+				${renderProvisioningDetails(environment.provisioning)}
 				${revealAction}
 			</article>`;
 	}).join('');
@@ -281,6 +282,27 @@ function renderCoreEnvironments(coreDiagnostics) {
 		</article>`;
 	}).join('');
 	elements.coreEnvironmentList.innerHTML = environmentCards + selectionCards;
+}
+
+function renderProvisioningDetails(provisioning) {
+	if (!provisioning || provisioning.status === 'idle') {return '';}
+	const fields = [
+		`status=${provisioning.status}`,
+		`attempt=${provisioning.attempt}`,
+		`trigger=${provisioning.trigger}`,
+		`stage=${provisioning.stage}`,
+		`percent=${provisioning.percent}`,
+	];
+	if (provisioning.status === 'failed' && provisioning.failure) {
+		fields.push(
+			`code=${provisioning.failure.code}`,
+			`started=${provisioning.failure.started}`,
+			`message=${provisioning.failure.message}`
+		);
+		if (provisioning.failure.stdout) {fields.push(`stdout=${provisioning.failure.stdout}`);}
+		if (provisioning.failure.stderr) {fields.push(`stderr=${provisioning.failure.stderr}`);}
+	}
+	return renderDetailBlock('managed-provisioning', fields.join('; '));
 }
 
 function formatBytes(bytes) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "singular-blockly",
-	"version": "0.87.0",
+	"version": "0.87.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "singular-blockly",
-			"version": "0.87.0",
+			"version": "0.87.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "singular-blockly",
 	"displayName": "Singular Blockly",
 	"description": "VS Code extension for visual Arduino & MicroPython programming with Blockly. Multi-board support, project-local Agent Skills, AI camera integration, PlatformIO integration, and 15 languages.",
-	"version": "0.87.0",
+	"version": "0.87.1",
 	"license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.109.0",

--- a/scripts/managed-runtime/evidence.test.js
+++ b/scripts/managed-runtime/evidence.test.js
@@ -14,7 +14,7 @@ const treeSha = 'b'.repeat(40);
 const vsixSha256 = 'c'.repeat(64);
 const manifestSha256 = 'd'.repeat(64);
 const artifactSha256 = 'e'.repeat(64);
-const requiredPathCases = ['unicode', 'space', 'special-characters', 'offline-restart'];
+const requiredPathCases = ['unicode', 'space', 'special-characters', 'default-global-storage-shape', 'offline-restart'];
 
 assert.deepStrictEqual(
   parseArgs(['--evidence', 'linux.json', '--evidence', 'windows.json']).evidences,
@@ -56,6 +56,10 @@ try {
   assert.throws(() => verifyEvidence([evidence('darwin', 'x64', { eventName: 'workflow_dispatch' }), ...x64.slice(1)], baseOptions), /eventName/);
   assert.throws(() => verifyEvidence([evidence('darwin', 'x64', { pathCases: ['/Users/private/project'] }), ...x64.slice(1)], baseOptions), /forbidden path/);
   assert.throws(() => verifyEvidence([evidence('darwin', 'x64', { pathCases: ['unicode'] }), ...x64.slice(1)], baseOptions), /Evidence failed/);
+  assert.throws(() => verifyEvidence([
+    evidence('darwin', 'x64', { pathCases: requiredPathCases.filter(pathCase => pathCase !== 'default-global-storage-shape') }),
+    ...x64.slice(1),
+  ], baseOptions), /Evidence failed/);
   assert.throws(() => verifyEvidence([evidence('darwin', 'x64', { offlineRestart: 'false' }), ...x64.slice(1)], baseOptions), /Evidence failed/);
   assert.throws(() => verifyEvidence([evidence('darwin', 'x64', { artifactSha256: 'f'.repeat(64) }), ...x64.slice(1)], baseOptions), /artifact/);
   assert.throws(() => verifyEvidence([evidence('darwin'), ...x64], baseOptions), /Duplicate evidence/);

--- a/scripts/managed-runtime/test-real-installation.js
+++ b/scripts/managed-runtime/test-real-installation.js
@@ -33,7 +33,12 @@ async function main() {
   const manifestSha256 = crypto.createHash('sha256').update(manifestBytes).digest('hex');
   const parent = path.resolve(argument('--root') || fs.realpathSync(os.tmpdir()));
   fs.mkdirSync(parent, { recursive: true });
-  const root = fs.mkdtempSync(path.join(parent, 'managed runtime 中文 & offline-'));
+  const sandboxRoot = fs.mkdtempSync(path.join(parent, '使用者 中文 & managed runtime-'));
+  const root = path.join(
+    sandboxRoot,
+    'AppData', 'Roaming', 'Code', 'User', 'globalStorage', 'Singular-Ray.singular-blockly', 'runtime-v1',
+  );
+  fs.mkdirSync(root, { recursive: true });
   const storage = new ManagedRuntimeStorage(root);
   let installerCalls = 0;
 
@@ -89,7 +94,7 @@ async function main() {
       arch: process.arch,
       artifactId: record.artifactId,
       artifactSha256: manifest.artifacts.find(artifact => artifact.id === record.artifactId)?.sha256,
-      pathCases: ['unicode', 'space', 'special-characters', 'offline-restart'],
+      pathCases: ['unicode', 'space', 'special-characters', 'default-global-storage-shape', 'offline-restart'],
       offlineRestart: true,
       success: true,
     };
@@ -98,8 +103,8 @@ async function main() {
     if (resultPath) { fs.writeFileSync(path.resolve(resultPath), `${JSON.stringify(result, null, 2)}\n`, { flag: 'wx' }); }
     process.stdout.write(`Real managed runtime installation passed on ${process.platform}/${process.arch}.\n`);
   } finally {
-    if (!hasFlag('--keep')) { fs.rmSync(root, { recursive: true, force: true }); }
-    else { process.stdout.write('Managed runtime test directory retained by explicit --keep.\n'); }
+    if (!hasFlag('--keep')) { fs.rmSync(sandboxRoot, { recursive: true, force: true }); }
+    else { process.stdout.write(`Managed runtime test directory retained at ${sandboxRoot}.\n`); }
   }
 }
 

--- a/scripts/managed-runtime/verify-evidence.js
+++ b/scripts/managed-runtime/verify-evidence.js
@@ -9,7 +9,7 @@ const { parseArgs, sha256File } = require('./collect-evidence');
 const SHA = /^[a-f0-9]{40,64}$/;
 const SHA256 = /^[a-f0-9]{64}$/;
 const MATRIX_X64 = ['darwin/x64', 'linux/x64', 'win32/x64'];
-const REQUIRED_PATH_CASES = ['offline-restart', 'space', 'special-characters', 'unicode'];
+const REQUIRED_PATH_CASES = ['default-global-storage-shape', 'offline-restart', 'space', 'special-characters', 'unicode'];
 const SENSITIVE_PATH = /(?:^|[\s"'])(?:[A-Za-z]:\\Users\\|\/Users\/|\/home\/|\/root\/)/;
 
 function readEvidence(filePath) {

--- a/specs/067-managed-platformio-environment/checklists/implementation.md
+++ b/specs/067-managed-platformio-environment/checklists/implementation.md
@@ -2,7 +2,7 @@
 
 **驗證日期**：2026-08-17
 
-**驗證分支**：`codex/067-managed-platformio-environment`
+**驗證分支**：`codex/130-managed-runtime-hotfix`
 
 **功能規格**：[spec.md](../spec.md)
 
@@ -80,9 +80,21 @@
 - [x] 根因為 reusable runtime workflow 的 `github.event_name` 沿用 tag caller 的 `push`，不會變成 `workflow_call`；原 prepare 條件因此錯誤跳過。Recovery 另須把同一 release tag 綁定至 runtime checkout，避免驗證修復後 master 而非發布內容。
 - [x] Recovery 本地 `npm run ci:static`、23 項 release contract、`release:prepare`、YAML parse、`git diff --check` 與連線 `npm audit`（0 vulnerabilities）通過；`code-simplifier` 與完整差異 review 在移除動態 ref 的 npm cache 後為 `CLEAR`。
 - [x] 本機 VS Code 1.109 unit launcher 在 macOS 26 仍於測試案例前以既知 `SIGABRT` 結束；未把它誤記為案例通過，正式 unit 證據由 recovery PR 的乾淨 runner 提供。
-- [ ] Recovery 修正 PR 必須通過乾淨 runner unit、CI、CodeQL 與必要 runtime matrix；合併後只能從 `master` dispatch 同一 immutable `v0.87.0`。
-- [ ] Recovery publish run 必須重新驗證 annotated tag、release tree、唯一 VSIX 與 checksum，並確認 GitHub Release、VS Code Marketplace、Open VSX 三端成功。
+- [x] Recovery PR #127 已通過必要 checks 並 squash merge 為 `225b950`；後續只從 `master` dispatch 同一 immutable `v0.87.0`。
+- [x] Recovery publish run `31983230776` 重新驗證 annotated tag、六平台 runtime、release tree、唯一 VSIX 與 checksum；GitHub Release、VS Code Marketplace、Open VSX 及最終三端 gate 全部成功。
+
+## issue #130／v0.87.1 hotfix 驗證
+
+- [x] 路徑預算分析確認預設 Windows `AppData/Roaming/Code/User/globalStorage/Singular-Ray.singular-blockly/runtime-v1` 加上原複合版本目錄後，PlatformIO 深層檔案路徑可逼近傳統 Win32 260 字元邊界；這是 issue #130 的風險因子而非已證實的唯一 installer 根因，先前真實 E2E 暫存根較短，未覆蓋正式路徑形狀。
+- [x] 新版本目錄改用固定長度 transaction UUID；install／transaction record 仍保留完整 runtime version、artifact id 與 manifest SHA，既有 `current.json` 相對目錄讀取契約不變。
+- [x] storage initialize 與 installer failure 都進入 provisioning 狀態；installer 新增 `managed-provisioning`、stage、code、started 與遮蔽／有界 stdout／stderr，service 保留 activation／editor-open／repair／workload 的 attempt 與 running／failed snapshot。
+- [x] 診斷 Core 卡片、複製摘要、AI repair packet 與 issue draft 納入 provisioning blocker 與有界 evidence；provider operational 不再掩蓋 managed 失敗，且 cancellation／project-process 仍 fail closed。
+- [x] `npm run test:managed-runtime` 139 項、`npm run test:managed-runtime:paths` 5 組、正式 `test:unit:ci` 1,225 項通過（1 項既有 Copilot AI E2E pending）；`npm run ci:static`、15 語系、production package、`npm run release:prepare` 與 `git diff --check` 全數通過。
+- [x] macOS ARM64 以 `--allow-release-candidate` 在 Unicode／空白／特殊字元上層與預設 global-storage 深度完成第二次真實 CPython／PlatformIO／mpremote 安裝、健康 probe 與離線重啟；省略候選旗標時依政策 fail closed。
+- [x] `npm audit --omit=dev --audit-level=high` 回報正式依賴 0 個已知漏洞；WebView provisioning evidence 使用既有 `escapeHtml` detail renderer，raw／URI-encoded managed root 與 token regression 通過。
+- [ ] Runtime-sensitive PR 的 Windows／macOS／Linux x64 與 release-candidate ARM64 真實 E2E evidence 都包含 `default-global-storage-shape` 並通過；乾淨 Windows F5 診斷可看到 attempt／stage 與遮蔽 installer evidence。
+- [ ] Arduino／CyberBrick 實機 smoke 確認 provider-primary 與 managed-primary 路由未回歸後，才允許 squash merge、annotated `v0.87.1` tag 與三端發布。
 
 ## 結論
 
-本機程式、封裝、安全與 Code Review，以及 F5、PR 六平台 runtime、乾淨 Windows／Linux 與 Arduino／CyberBrick 實機閘門均已通過，T061 已完成。剩餘工作僅限 recovery 修正 PR 與同一 immutable `v0.87.0` 的三端發布驗證。
+`v0.87.0` recovery 與三端發布已由 run `31983230776` 完成。`v0.87.1` hotfix 的程式、SDD、本地全量 gate、code-simplifier、安全審查與本地 Code Review 已完成；仍需 Phase 3.5 核准後的六平台 runtime evidence、乾淨 Windows F5 與 Arduino／CyberBrick 實機 smoke，才能 squash merge、建立 annotated tag 並發布。

--- a/specs/067-managed-platformio-environment/checklists/release-readiness.md
+++ b/specs/067-managed-platformio-environment/checklists/release-readiness.md
@@ -71,8 +71,18 @@
 - [x] CHK043 是否定義亮色、暗色、forced-colors、reduced-motion 及未定義 CSS token 的可驗收標準？[Accessibility, Spec §FR-036, SC-014]
 - [x] CHK044 動態進度文案、ARIA terminal state 與 15 語系需求是否一致，且沒有只驗收視覺動畫而忽略輔助科技？[Accessibility, Spec §FR-026, FR-035–FR-037]
 
+## issue #130／v0.87.1 增量品質
+
+- [x] CHK045 Windows 正式預設 global storage 形狀、Unicode／空白／特殊字元上層與固定長度 version directory 是否共同形成可重現的路徑預算驗收？[Measurability, Spec §FR-038, FR-041, SC-015]
+- [x] CHK046 runtime／artifact 身分移出目錄名稱後，是否仍由 install record 與 manifest SHA 保留供應鏈及向後相容依據？[Consistency, Spec §FR-004–FR-005, FR-038]
+- [x] CHK047 provisioning running／failed snapshot 是否完整定義 attempt、trigger、stage、percent、時間與最近失敗的建立、成功清除及 Extension 重啟行為？[Completeness, Spec §FR-039]
+- [x] CHK048 installer evidence 是否同時規定資料來源、最大長度、控制字元處理、home／workspace／managed root／credential／token 遮蔽與一般 log 禁止 raw output？[Security, Spec §FR-039, SC-016]
+- [x] CHK049 provider operational 時 managed provisioning blocker 是否仍須呈現，且診斷、AI packet 與人工 issue draft 的欄位一致？[Consistency, Spec §FR-015, FR-039, SC-016]
+- [x] CHK050 `managed-provisioning` 是否只在 probe／prepare 可 fallback，並對 cancellation、project-process 與 post-spawn 提供明確零 fallback 負面條件？[Security, Spec §FR-040, SC-017]
+
 ## 備註
 
 - 完成方式：由 PR reviewer 逐項判斷需求是否足以實作及驗收；若答案為否，先修訂規格再進入 release gate。
 - 本清單不替代 `tasks.md`、自動測試、實機 smoke 或安全審查紀錄。
 - 2026-08-16 已依更新後 spec／plan／contracts 與 F5 回饋完成 44 項需求品質復核。
+- 2026-08-17 已依 issue #130 hotfix 的 spec／plan／tests 完成 CHK045－CHK050 增量品質復核。

--- a/specs/067-managed-platformio-environment/checklists/requirements.md
+++ b/specs/067-managed-platformio-environment/checklists/requirements.md
@@ -39,8 +39,17 @@
 - [x] 已區分 OTA 設定的真實 determinate 里程碑與 OTA 清除的 indeterminate 狀態，禁止虛構百分比
 - [x] 已涵蓋亮色、暗色、高對比、reduced-motion、ARIA 與 15 語系需求
 
+## issue #130 hotfix 需求覆蓋
+
+- [x] 已定義固定長度內部版本目錄與 install record 身分分離，並保留既有 record 相容性
+- [x] 已明定真實 E2E 必須使用 VS Code 預設 global storage 形狀，不得以短暫存根替代 Windows 路徑預算驗證
+- [x] 已定義 provisioning attempt／trigger／stage／percent／recent failure 的生命週期、資料邊界與遮蔽上限
+- [x] 已把 `managed-provisioning` fallback 限制在 probe／prepare，取消與 project-process 保持 fail closed
+- [x] 已為預設路徑真實安裝、診斷證據一致性、隱私與 fallback 次數建立可量測成功指標
+
 ## 備註
 
 - 既有 spec 063 的 provider 引導被視為相容性契約，不在本功能中移除。
 - 路徑、權限、外部 PR 安全與發布閘門已在前期討論完成產品決策，無需額外澄清標記。
 - 2026-08-16 依 F5 回饋新增 US7／US8、FR-032－FR-037 與 SC-012－SC-014；需求與既有 Project Skill、OTA、i18n 及安全契約一致。
+- 2026-08-17 依 issue #130 新增 FR-038－FR-041 與 SC-015－SC-017；路徑預算、背景安裝可觀測性、隱私與 fail-closed fallback 契約一致。

--- a/specs/067-managed-platformio-environment/checklists/security.md
+++ b/specs/067-managed-platformio-environment/checklists/security.md
@@ -21,12 +21,13 @@
 - [x] install 與 cleanup 共用具 owner、PID、建立時間與 lease 的原子 lock；有效或 PID 仍存活的 lock 不刪除。序列化 stale-lock 回收的 guard 也具有短租約，owner 崩潰後可復原，malformed guard 維持 fail-closed。
 - [x] staging／version 只有在 marker 與 transaction ownership 可證明時才能清除；未知檔、provider penv 與 workspace 永不納入 cleanup。
 - [x] 安裝在 immutable candidate 完成健康 probe 後才原子寫入 `current.json`；checksum、ENOSPC、權限、probe 或中斷失敗都保留上一個 current。
+- [x] 新 immutable version directory 只使用固定長度 transaction UUID；完整 runtime／artifact id 保留在 record，避免不受信任的上游名稱或預設 Windows global storage 深度無限制放大每個子檔案路徑。
 
 ## 程序、信任與 fallback
 
 - [x] managed Core、Arduino PlatformIO、monitor 與 installer 的新程序路徑使用 argv 邊界與 `shell: false`；特殊字元不會變成 shell 語法。既有 provider-only Windows compatibility path 保留原行為但不接收未驗證動態參數。取消／逾時會終止 POSIX process group 或 Windows process tree，等待 close 後才回報完成。
 - [x] runtime-only 安裝／probe 不讀取專案程式；pkg install、build、upload、monitor 與裝置操作在 workspace untrusted 時拒絕執行。
-- [x] fallback 採 fail-closed 分類，只允許 process spawn 前的本機 executable／import／permission／managed-store corruption；`CoreEnvironmentManager` 是雙 Core 唯一 authority，MicroPython 不會在 manager 禁止後再走 legacy provider。網路、編譯、設定、裝置、serial、取消與 post-spawn 錯誤不得切換 Core 或重複上傳。
+- [x] fallback 採 fail-closed 分類，只允許 process spawn 前的本機 executable／import／permission／managed-store corruption，以及明確 `managed-provisioning` probe／prepare 失敗；`CoreEnvironmentManager` 是雙 Core 唯一 authority，MicroPython 不會在 manager 禁止後再走 legacy provider。網路、編譯、設定、裝置、serial、取消與 project-process／post-spawn 錯誤不得切換 Core 或重複上傳。
 - [x] Arduino provider 優先、Python managed 優先，sticky 選擇只影響 Singular 自己的操作，不修改或清理 provider 擁有的 Core。
 
 ## Workspace 同意與 WebView 呈現
@@ -38,10 +39,12 @@
 - [x] OTA 共用進度只消費既有、已驗證的 operation state；動態摘要與步驟使用 `textContent`，未使用 `innerHTML`、`eval` 或可由 Host payload 注入的 selector／style。
 - [x] OTA 設定與清除互斥，running state 同時停用衝突控制項；清除 request 仍只傳已選 USB port，不擴張 WebView 到 Host 的權限或秘密資料面。
 - [x] 診斷面板的 managed repair、cleanup、既有 auto repair 與 retest 使用共用 busy gate，不在安裝交易或修復流程中交錯讀寫狀態。
+- [x] 同一 Extension Host 的 background ensure 與 explicit repair 共用單一 provisioning Promise，避免 installer lock 等待期間由兩個 attempt 互相覆寫診斷狀態；跨視窗仍由受管 store lock 序列化。
 
 ## 隱私、CI 與發布
 
 - [x] logs、診斷、clipboard 與 issue draft 遮蔽 home／workspace、proxy credentials、token-like secrets 與敏感 URL；managed storage 對 WebView 與可分享輸出只提供穩定摘要。顯示實際 managed root 時，WebView 只送固定 command，由 Extension Host 直接呼叫本機檔案管理員，不回傳或記錄完整路徑。
+- [x] managed installer failure evidence 在進入診斷、AI packet 或 issue draft 前遮蔽 raw／URI-encoded managed root、home、workspace、credentials 與 token，移除控制字元並限制為 4,000 字元；background log 只記 attempt／stage，不記 raw stdout／stderr。
 - [x] evidence 只記錄 OS／arch、runner、path case 名稱、PR／event、head／tree、VSIX／manifest／artifact SHA 與結果，不保存原始使用者路徑或環境變數。
 - [x] workflows 使用最小 `contents: read` 權限、SHA-pinned actions，未使用 `pull_request_target`；具網路與執行未信任程式碼的真實矩陣需由 label／release gate 核准。可執行 checkout 直接綁定 GitHub event immutable SHA；reusable release workflow 必須由 caller 傳入同一 annotated release tag 作 `candidate_ref`，runtime 矩陣不使用 npm dependency cache。跨 job 輸出的 candidate SHA 僅能用於 evidence 比對，不能決定後續執行內容。
 - [x] evidence verifier 拒絕錯誤 PR／event、過期 commit／tree、不同 VSIX／manifest／artifact、缺少或重複平台與未完成 path/offline cases。
@@ -49,4 +52,4 @@
 
 ## 結論
 
-下載、archive、路徑、子程序、workspace consent、WebView DOM、log、cleanup 與 GitHub workflow trust boundaries 均已有 fail-closed 實作與自動化負面測試。正式發布仍必須通過 `implementation.md` 中尚未完成的遠端矩陣、F5 視覺檢查與實機 smoke。
+下載、archive、路徑、子程序、workspace consent、WebView DOM、log、cleanup 與 GitHub workflow trust boundaries 均已有 fail-closed 實作與自動化負面測試。`v0.87.1` 正式發布仍必須通過 `implementation.md` 中尚未完成的六平台遠端矩陣、乾淨 Windows F5 與實機 smoke。

--- a/specs/067-managed-platformio-environment/data-model.md
+++ b/specs/067-managed-platformio-environment/data-model.md
@@ -26,7 +26,7 @@
 
 ## InstallRecord
 
-只有完成健康檢查的版本才可建立；`current.json` 以它作為唯一 ready 訊號。包含 schema、runtime／artifact id、manifest SHA、安裝時間、`versions/` 下的相對目錄、工具相對路徑／版本及 probes。
+只有完成健康檢查的版本才可建立；`current.json` 以它作為唯一 ready 訊號。包含 schema、runtime／artifact id、manifest SHA、安裝時間、`versions/` 下的相對目錄、工具相對路徑／版本及 probes。新版本目錄使用固定長度 transaction UUID；完整 runtime／artifact id 不再重複編入路徑，但既有 record 的相對目錄仍可讀取，以維持升級相容。
 
 ```text
 missing -> staging -> verified -> committed
@@ -41,6 +41,10 @@ committed -> staging-update -> committed(new)
 
 接受 `activation|editor-open` trigger，先讀取本機狀態，再將同視窗同時發生的初始化合併為單一 in-flight Promise。`ready` 不安裝、`unsupported` 不下載、`missing|invalid` 進入同一 `ensureReady()` 交易；完成或失敗後釋放 in-flight 狀態，允許後續 editor-open 或上傳安全重試。
 
+## ManagedRuntimeProvisioningState
+
+記憶體內狀態為 `idle|running|failed`，每次交易遞增 `attempt`。running 保留 `trigger`、`stage`、`percent`、`startedAt` 與 `updatedAt`；failed 另含 `failedAt` 與 `ManagedRuntimeProvisioningFailure`。失敗物件固定 `failureDomain: managed-provisioning`，並包含 installer `stage`、穩定 `code`、子程序是否已開始、遮蔽且最多 4,000 字元的 message／stdout／stderr。這些資料不持久化，Extension 重啟後由實際 install record 重新判定。
+
 ## CoreEnvironment
 
 提供給工作負載的不可變執行描述：`provider|managed` id、來源、`CoreInvocation`、Python／mpremote 路徑、storage root 與 `CoreHealth`。
@@ -53,7 +57,7 @@ committed -> staging-update -> committed(new)
 
 ## FailureClass
 
-`spawn`、`missing-executable`、`python-import`、`permission`、`local-store-corruption` 可在 project process 前 fallback。
+`spawn`、`missing-executable`、`python-import`、`permission`、`local-store-corruption` 可在 project process 前 fallback。`managed-provisioning` 只允許於 probe／prepare 且非取消時 fallback。
 
 `compile`、`project-config`、`dns`、`proxy`、`tls`、`registry`、`device`、`serial`、`cancelled`、`unknown-after-start` 禁止 fallback。分類輸入包含 phase、是否 spawn、exit code、signal 與遮蔽後 stderr pattern；未知採禁止 fallback。
 

--- a/specs/067-managed-platformio-environment/plan.md
+++ b/specs/067-managed-platformio-environment/plan.md
@@ -144,17 +144,17 @@ scripts/
 ### 2. 儲存、權限與原子交易
 
 - 預設根目錄為 `context.globalStorageUri/runtime-v1`；自訂 `singularBlockly.managedRuntime.path` 為 machine scope，只接受本機絕對路徑，不允許 workspace-relative、UNC／network path、根目錄或既有 symlink component。
-- 儲存根先以 `.singular-managed-runtime-root.json` 證明所有權；全新目錄只有在為空時可認領，非空且未受管理的自訂路徑直接拒絕。其下含 `downloads/`、`staging/`、`versions/<runtime-id>/`、`current.json`、`locks/install.lock` 與 `workspaces/<sha256-workspace>/`。工作區 hash 使用 canonical URI，不把原始路徑寫入公開診斷。
+- 儲存根先以 `.singular-managed-runtime-root.json` 證明所有權；全新目錄只有在為空時可認領，非空且未受管理的自訂路徑直接拒絕。其下含 `downloads/`、`staging/`、`versions/<transaction-uuid>/`、`current.json`、`locks/install.lock` 與 `workspaces/<sha256-workspace>/`。固定長度 UUID 為 Windows 預設 global storage 保留路徑預算；完整 runtime／artifact id 只存於 record。工作區 hash 使用 canonical URI，不把原始路徑寫入公開診斷。
 - 安裝先取得跨視窗 lock，再於同一檔案系統建立具 transaction marker 的 staging metadata，並直接準備不可變候選版本以保留 Python venv 的絕對路徑語意。健康檢查至少涵蓋 Python、pip、受測範圍內的 `pio --version`、`pio system info --json-output` 與 `mpremote version`；全部成功後最後原子替換 `current.json`。
 - `current.json` 永遠指向完整且已驗證版本。cleanup 與安裝／修復共用同一 lock，只清理由有效 transaction marker、版本 ownership marker 或 manifest hash 證明屬於 Singular 的項目；未知 staging／版本與非受管檔案保持不動。更新失敗保留 current 與前一個可用版本。
-- `onStartupFinished` 呼叫 background coordinator；若狀態不是 ready／unsupported，開始 `ensureReady()`。開啟 Blockly 再呼叫同一 coordinator，同視窗共用 in-flight Promise，跨視窗使用 install lock。背景失敗只記錄遮蔽後錯誤並允許之後重試，不阻止編輯器或 provider 引導。
+- `onStartupFinished` 呼叫 background coordinator；若狀態不是 ready／unsupported，開始 `ensureReady()`。開啟 Blockly 再呼叫同一 coordinator；同一 Extension Host 的 ensure／repair 共用單一 in-flight provisioning Promise，跨視窗使用 install lock。service 在記憶體保留 provisioning attempt、trigger、stage、percent 與最近失敗；installer 將受限長度且完成 privacy redaction 的 message／stdout／stderr 附在結構化失敗。背景 log 只寫 stage／attempt，不輸出 raw evidence；失敗不阻止編輯器或 provider 引導。
 
 ### 3. 雙 Core 選擇與 fallback
 
 - Provider Core 仍由 `PlatformioInvocationResolver` 從官方 customPATH、provider penv 與 PATH 探測；同時存在時固定優先官方 `platformio.platformio-ide` 再 PIOArduino，診斷呈現來源。
 - Singular Core 由 install record 產生絕對 Python／pio／pip／mpremote 路徑與專用環境變數：`PLATFORMIO_CORE_DIR`、`PLATFORMIO_CACHE_DIR`、`PLATFORMIO_WORKSPACE_DIR`、`PLATFORMIO_BUILD_DIR`、`PLATFORMIO_LIBDEPS_DIR`、`PLATFORMIO_SETTING_ENABLE_TELEMETRY=No`、`PLATFORMIO_SETTING_ENABLE_PROMPTS=No`、`PLATFORMIO_NO_ANSI=true`。
 - Arduino 操作選擇 provider → managed；Python／mpremote 選擇 managed → provider。選擇結果與最近本機故障在視窗記憶體中依 workload sticky，重新測試、修復或視窗重啟清除。
-- 每個候選先執行不載入專案的版本／能力探測。Arduino 真正啟動前先在已信任 workspace 執行 `pio pkg install --project-dir <project>`；只有 spawn、missing executable、Python import、permission、local Core store corruption 等本機環境錯誤可在真正 `pio run -t upload` 之前切換一次。
+- 每個候選先執行不載入專案的版本／能力探測。Arduino 真正啟動前先在已信任 workspace 執行 `pio pkg install --project-dir <project>`；只有 spawn、missing executable、Python import、permission、local Core store corruption，以及明確標記為 `managed-provisioning` 的 probe／prepare 失敗，可在真正 `pio run -t upload` 之前切換一次。
 - 編譯／設定、DNS／proxy／TLS／registry、裝置／serial 與 cancellation 錯誤不 fallback；`pio run -t upload` spawn 成功即視為上傳已開始，後續任何 exit code 都不以另一 Core 重試。
 
 ### 4. 子程序、監控與 Workspace Trust
@@ -168,6 +168,7 @@ scripts/
 
 - 現有 PlatformIO 診斷 schema 升級為雙環境：每個 Core 顯示來源、版本、健康、受管理根目錄摘要、用量、工具與 package 狀態；另顯示 Arduino／Python 目前選擇及最近 fallback 類別。
 - package 狀態在尚未執行真實 project package install 前為 `unknown`，不以網路探測或假 install 宣告健康。
+- 診斷 session 會納入 managed provisioning 的 running／failed snapshot；失敗時整體狀態至少為 degraded，即使 provider 可用也不得把背景安裝失敗誤報為完全 operational。複製摘要、AI repair packet 與 issue draft 共用遮蔽後 attempt／stage／code／bounded stdout／stderr。
 - 複製摘要使用現有 privacy redactor，workspace 與 home 轉成穩定 token；不輸出完整 manifest URL query、專案內容、環境變數值或 secrets。
 - managed Core 卡片提供「開啟 Singular Core 資料夾」動作；WebView 只送出固定 command，不攜帶路徑，Extension Host 才以本機 `revealFileInOS` 開啟 managed root。完整路徑不進入 WebView state、log、clipboard 或 issue draft。
 - repair 建立新交易並只切換 managed current；cleanup 列出並驗證目標後只刪除 managed-owned 項目，不觸碰 provider、專案或自訂路徑中的未知檔案。新增文字全部經 15 語系流程。
@@ -180,7 +181,7 @@ scripts/
 
 ### 7. CI、PR 與發布閘門
 
-- `ci.yml` 的每個 PR 在 Windows／macOS／Linux 以本機 fake artifact 執行安裝、Unicode／空白／特殊字元／長路徑、checksum、permission 與 rollback 測試，不連外，維持 `pull_request`、`contents: read`、零 secrets。
+- `ci.yml` 的每個 PR 在 Windows／macOS／Linux 以本機 fake artifact 執行安裝、Unicode／空白／特殊字元／長路徑、checksum、permission 與 rollback 測試，不連外，維持 `pull_request`、`contents: read`、零 secrets。真實 E2E 的 sandbox 需模擬 VS Code 預設 global storage 層級，且上層目錄含 Unicode、空白與合法特殊字元，避免短暫存根掩蓋 Windows 路徑預算缺陷。
 - `runtime-installation.yml` 只由 `pull_request` 的 label gate 或受限 `workflow_dispatch` 執行。`runtime-e2e-approved` 執行三 OS x64 真實下載；`release-candidate` 加入目前宣告支援且可由標準 GitHub-hosted runner 執行的 ARM64。外部 PR 在維護者核准前不執行真實下載，且永不使用 `pull_request_target` 執行 PR 程式碼。所有會執行候選程式碼的 checkout 直接使用 GitHub event 綁定的 immutable SHA；reusable publish caller 則明確傳入同一 release tag 作 `candidate_ref`，且動態 release ref 的真實矩陣不寫入 npm dependency cache。被呼叫 workflow 的 `github.event_name` 沿用 caller event，不能以 `workflow_call` 字串判斷是否執行；prepare job 輸出的 SHA 只供 evidence 身分比對，不得再作為可執行 checkout ref。
 - 底層 artifact selector 對 `release-candidate` 預設 fail closed；正式 Extension factory 因 publish workflow 強制要求完整 ARM64 release matrix，才明確啟用 manifest 內的 ARM64 候選。缺少對應 evidence 時不得發布該 factory policy。
 - evidence JSON 直接讀取真實 E2E result，記錄 PR／event、head SHA、tree SHA、VSIX SHA-256、runtime manifest SHA-256、runner image／arch、artifact id／SHA-256 與測試結果；verifier 必須將 artifact 逐項對回 manifest。新 commit 使 check 與 evidence 自動失效。

--- a/specs/067-managed-platformio-environment/quickstart.md
+++ b/specs/067-managed-platformio-environment/quickstart.md
@@ -32,7 +32,7 @@ VSCODE_TEST_TEMP_DIR=/tmp/singular-blockly-consent-progress npx vscode-test \
 2. 在背景安裝期間從活動列開啟中文與空白路徑 workspace 的 Blockly 編輯器，確認狀態重查但 editor 不被阻擋，且 installer 不重複啟動。
 3. 背景初始化完成後才執行 CyberBrick USB，確認上傳直接重用 managed runtime；上傳端 `ensureReady()` 仍能在背景失敗時續裝。
 4. 重新載入並離線，確認重用 current install record。
-5. 開啟診斷，確認兩套 Core 分區且複製摘要無完整 home／workspace。
+5. 開啟診斷，確認兩套 Core 分區且複製摘要無完整 home／workspace。另以受控 installer failure 模擬 `installing-platformio` 失敗，確認 managed 區段、AI packet 與 issue draft 都顯示相同 attempt／stage／code，但不含完整 managed root 或 raw credentials。
 6. 安裝官方 provider，確認 Arduino 選 provider；在 project process 前模擬本機 executable 故障，確認只 fallback 一次。
 7. 模擬編譯、DNS、serial 與 upload-started 後失敗，確認不 fallback。
 8. 把 workspace 設為不信任，確認 runtime 背景準備仍可做不載入專案的工具安裝，但 pkg install、build、upload 與 monitor 均不啟動。
@@ -50,3 +50,5 @@ npm run test:managed-runtime:e2e -- --allow-network
 ```
 
 沒有 `--allow-network` 必須拒絕連外。完成前另執行 `npm run ci:static`、unit、integration 與 package；tag 重建 VSIX smoke 成功後才能發布。
+
+真實 E2E evidence 的 `pathCases` 必須包含 `default-global-storage-shape`；在 Windows 檢查其 sandbox root 具有 `AppData/Roaming/Code/User/globalStorage/Singular-Ray.singular-blockly/runtime-v1` 層級及 Unicode／空白／特殊字元上層。若只在較短暫存目錄成功，不得視為 issue #130 的路徑驗證通過。

--- a/specs/067-managed-platformio-environment/research.md
+++ b/specs/067-managed-platformio-environment/research.md
@@ -89,3 +89,15 @@ Archive 解壓前列舉全部 entry。`python-build-standalone` 的 `install_onl
 **理由**：官方 installer 的 stable 流程會以 pip `-U platformio` 取得最新版本，未提供產品所需的精確 Core pin；只把測試範圍寫在文件卻不執行會讓未驗證大版本進入環境。constraint 保留官方 penv 建立流程，同時在安裝前解析與安裝後 probe 兩側限制相容性。
 
 **來源**：[PlatformIO custom integration](https://docs.platformio.org/en/stable/core/installation/integration.html)、[PlatformIO installer source](https://github.com/platformio/platformio-core-installer/blob/develop/pioinstaller/core.py)。
+
+## 決策 12：用固定長度版本目錄保留 Windows global storage 路徑預算
+
+**決策**：`versions/` 下的新不可變候選只使用 transaction UUID；runtime version 與 artifact id 繼續寫入 install／transaction record，不再編入目錄名稱。真實 E2E 根目錄模擬 VS Code 預設 `AppData/Roaming/Code/User/globalStorage/<extension-id>/runtime-v1` 層級，並保留 Unicode、空白與合法特殊字元上層。
+
+**理由**：issue #130 的 Windows 安裝在 `installing-platformio` 結束，但因舊版遺失 stderr，無法證明單一底層根因。獨立路徑預算分析顯示，原始版本目錄同時重複 runtime version、完整 artifact id 與 UUID；加上預設 global storage 與 PlatformIO 套件深層檔名後，常見路徑可逼近傳統 Win32 260 字元邊界。先前真實矩陣使用較短暫存根，因此能驗證 artifact／架構，卻未驗證實際安裝路徑預算。固定長度內部識別碼可降低所有套件檔案深度，且不犧牲 record 身分、原子交易或向後讀取既有版本；結構化 evidence 則用來確認任何仍存在的實際 installer 根因。
+
+## 決策 13：背景安裝失敗保留有界結構化證據
+
+**決策**：installer 以 stage、code、started、message、stdout、stderr 建立 `managed-provisioning` 失敗；service 保留最近 running／failed snapshot，診斷、AI packet 與人工 issue draft使用相同資料。所有字串先遮蔽 home／managed root／workspace／credentials／token，再移除控制字元並限制為 4,000 字元；一般 background log 僅記 stage 與 attempt。
+
+**理由**：只回報 exit code 1 無法區分路徑、proxy、pip 或權限原因；但把原始安裝器輸出直接寫入 log 或 issue 會洩漏本機路徑與秘密。有界、共用且先遮蔽的 volatile evidence 能讓 provider 仍可工作時也看見 managed Core 阻擋，並避免建立新的永久敏感資料面。

--- a/specs/067-managed-platformio-environment/spec.md
+++ b/specs/067-managed-platformio-environment/spec.md
@@ -202,6 +202,10 @@
 - **FR-035**：CyberBrick OTA 設定與 OTA 清除必須共用單一進度呈現區，且在各自 Host request 送出前進入可見的 running state。
 - **FR-036**：共用進度呈現必須使用已定義的專案 theme token，支援亮色、暗色、forced-colors 與 prefers-reduced-motion；不得依賴未定義的 CSS 變數。
 - **FR-037**：OTA 設定必須依已完成里程碑提供 determinate progress；沒有中間事件的 OTA 清除必須省略 `aria-valuenow` 並呈現 indeterminate progress，直到成功或失敗結果才進入 terminal state。
+- **FR-038**：不可變版本目錄必須使用固定長度、與 runtime／artifact 顯示名稱解耦的交易識別碼；完整 runtime 與 artifact 身分保留在 install record，不得重複編入 Windows 深層預設儲存路徑。
+- **FR-039**：activation、editor-open、repair 或 workload 觸發的 managed runtime provisioning 必須保留記憶體內的 attempt、trigger、stage、percent、開始／更新／失敗時間與最近一次結構化失敗；失敗證據必須限制長度並遮蔽 home、managed root、workspace、credentials 與 token。
+- **FR-040**：`managed-provisioning` 失敗只可在 probe／prepare 且專案程序尚未開始時觸發單次 Core fallback；使用者取消與任何 project-process 階段一律禁止 fallback。
+- **FR-041**：Windows 真實 runtime E2E 必須在形狀等同 VS Code 預設 `AppData/Roaming/Code/User/globalStorage/<extension-id>/runtime-v1`、且上層含 Unicode、空白與合法特殊字元的隔離路徑執行，不得以過短暫存根取代正式路徑預算驗證。
 
 ### 核心概念
 
@@ -231,6 +235,9 @@
 - **SC-012**：一般資料夾在安全詢問取消後，Project Skill 安裝與 workspace 設定呼叫次數皆為 0，且受保護目錄的檔案差異數為 0。
 - **SC-013**：OTA 設定與清除的自動化契約 100% 證明共用進度卡在 Host request 前可見；清除執行期間不得出現虛構的 `aria-valuenow`。
 - **SC-014**：共用進度元件在亮色、暗色、高對比與 reduced-motion 驗收中都具有可辨識 running、succeeded 與 failed 狀態，未定義 theme token 使用數為 0。
+- **SC-015**：預設 Windows global storage 形狀的 x64／ARM64 真實安裝、版本 probe 與離線重啟全數通過，且最深受測 PlatformIO 檔案路徑不因版本目錄的冗長名稱超出相容預算。
+- **SC-016**：所有 managed installer 階段失敗都能在診斷摘要、AI repair packet 與人工 issue draft 中看到同一 attempt／stage／code 與有界 stdout／stderr；未遮蔽完整本機路徑數量為 0。
+- **SC-017**：`managed-provisioning` 在 probe／prepare 的允許案例最多 fallback 一次；取消及 project-process 案例的自動 fallback 次數為 0。
 
 ## 假設
 

--- a/specs/067-managed-platformio-environment/tasks.md
+++ b/specs/067-managed-platformio-environment/tasks.md
@@ -223,8 +223,21 @@
 - [x] T085 [P] 以 `inputs.release_candidate` 啟動 reusable prepare，新增 caller 提供的 `candidate_ref`，讓 prepare、x64、ARM64 與 evidence gate 都 checkout 同一 release tag，並移除動態 ref 矩陣的 npm dependency cache 於 `.github/workflows/runtime-installation.yml` 與 `.github/workflows/publish.yml`
 - [x] T086 [P] 新增 caller event 不得假設為 `workflow_call`、publish／runtime 必須共用 release tag、四個 executable checkout ref 及 runtime 不得寫入 npm cache 的回歸契約於 `scripts/release/prepare-release.test.js`
 - [x] T087 重跑 release／靜態／安全測試、code-simplifier 與完整本地 Code Review，更新 recovery SDD 證據於 `specs/067-managed-platformio-environment/checklists/implementation.md`
-- [ ] T088 建立 recovery 修正 PR，通過乾淨 runner unit、CI、CodeQL 與必要 runtime matrix後 squash merge
-- [ ] T089 從 `master` dispatch 同一 annotated `v0.87.0`，驗證 runtime、唯一 VSIX、checksum 與三個發布端，不刪除或重建 tag
+- [x] T088 建立 recovery 修正 PR，通過乾淨 runner unit、CI、CodeQL 與必要 runtime matrix後 squash merge
+- [x] T089 從 `master` dispatch 同一 annotated `v0.87.0`，驗證 runtime、唯一 VSIX、checksum 與三個發布端，不刪除或重建 tag
+
+---
+
+## Phase 16：issue #130 managed runtime hotfix 與 v0.87.1
+
+**目的**：修正 Windows 預設 global storage 路徑預算造成的 PlatformIO 安裝失敗，讓背景 provisioning 失敗可診斷並維持 fail-closed fallback，準備 `v0.87.1`。
+
+- [x] T090 [P] 以 Windows 預設 global storage 層級計算 issue #130 的最深 PlatformIO 路徑，確認原本 runtime／artifact／UUID 複合版本目錄會逼近傳統 Win32 路徑邊界
+- [x] T091 將新版本目錄縮短為固定長度 transaction UUID，保留 install record 的完整 runtime／artifact 身分與既有 record 向後相容於 `src/services/managedRuntimeInstaller.ts` 及相關測試
+- [x] T092 [P] 建立涵蓋 storage initialize 與 installer 的 attempt／trigger／stage／percent／recent failure provisioning state，保存遮蔽且有界的 message／stdout／stderr於 `src/types/managedRuntime.ts`、`src/services/managedRuntimeService.ts` 與 `src/services/managedRuntimeInstaller.ts`
+- [x] T093 將 `managed-provisioning` 納入 probe／prepare fallback、雙 Core 診斷卡片、AI repair packet 與人工 issue draft，補 cancellation／project-process fail-closed、WebView escaping 及 privacy regression 於 `src/services/`、`media/js/platformioDiagnostic.js` 與 `src/test/`
+- [x] T094 將真實 E2E root 改為預設 global storage 形狀，執行 managed runtime、特殊路徑、完整 unit／static／package／release gates，並更新 `specs/067-managed-platformio-environment/checklists/implementation.md`
+- [ ] T095 執行 security-checker、code-simplifier 與 local Code Review 收斂；同步 `0.87.1` 版本／雙語 CHANGELOG，取得 Phase 3.5 後才 push、建立 PR、執行完整 runtime matrix 與發布
 
 ---
 
@@ -237,7 +250,7 @@
 - US1 → US2：CoreEnvironmentManager 需要可用的 managed provider。
 - US2 → US5／US4：provider 相容與診斷需要完成雙 Core 路由。
 - US3 可在 US1 完成後與 US2 並行；US6 可在 Phase 2 後先做 evidence 工具，但 workflow 完整驗證依 US1／US3。
-- Phase 9 依所有納入發布的故事完成；Phase 10 是 F5 驗收回饋的收斂增量；Phase 11 重新審查完整有效差異；Phase 12 完成本地發布契約；Phase 13 再驗證已提交分支的零寫入與 fallback authority；Phase 14 收斂 PR 首輪遠端安全與證據閘門 finding；Phase 15 只修復既有 immutable tag 的 workflow recovery，不改變 `v0.87.0` release tree。
+- Phase 9 依所有納入發布的故事完成；Phase 10 是 F5 驗收回饋的收斂增量；Phase 11 重新審查完整有效差異；Phase 12 完成本地發布契約；Phase 13 再驗證已提交分支的零寫入與 fallback authority；Phase 14 收斂 PR 首輪遠端安全與證據閘門 finding；Phase 15 只修復既有 immutable tag 的 workflow recovery，不改變 `v0.87.0` release tree；Phase 16 以 issue #130 的 Windows 正式路徑形狀為 hotfix gate，完成後才進入 `v0.87.1` 發布。
 - US7 的同意 gate 先於任何 workspace-local Skill／設定寫入；US8 與 managed runtime 安裝彼此獨立，可在 US7 測試完成後平行驗證。
 
 ### 平行機會
@@ -269,7 +282,8 @@
 8. Phase 10：依 F5 回饋加固使用者同意邊界與 OTA 共用進度。
 9. Phase 11：以完整工作樹反覆 review／fix／verify，直到沒有可採納 finding。
 10. Phase 12－15：完成 `0.87.0` 本地發布契約，對已提交完整差異執行安全重審，收斂 PR 遠端 CodeQL／evidence finding，並以新 PR 修復不可變 tag 的發布 workflow。
+11. Phase 16：縮短 Windows managed runtime 內部路徑、補齊背景安裝失敗證據與 fallback 契約，通過完整 release-candidate 矩陣後發布 `0.87.1`。
 
 ## 任務格式驗證
 
-全部 91 個任務（含 T024A／T024B）皆使用 `- [ ] Txxx [P?] [US?] 描述＋明確檔案路徑`；Setup、Foundational 與收斂任務不含故事標籤，故事階段皆含對應 `[USn]`。T061 已由遠端矩陣、F5、乾淨 OS 與實機 smoke 正式證據完成；T088 保持未完成直到 recovery PR 完成，T089 保持未完成直到同一 `v0.87.0` recovery publish run 驗證三個發布端。
+全部 97 個任務（含 T024A／T024B）皆使用 `- [ ] Txxx [P?] [US?] 描述＋明確檔案路徑`；Setup、Foundational 與收斂任務不含故事標籤，故事階段皆含對應 `[USn]`。T061 已由遠端矩陣、F5、乾淨 OS 與實機 smoke 正式證據完成；T088／T089 已由 PR #127 與成功的 recovery publish run `31983230776` 證實完成；T095 在 v0.87.1 Phase 3.5、遠端矩陣與發布完成前保持未完成。

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,9 +83,12 @@ export async function activate(context: vscode.ExtensionContext) {
 			}).then(result => {
 				log('[managed-runtime] background initialization completed', 'info', result);
 			}).catch(error => {
+				const provisioning = managedRuntimeService?.getProvisioningState();
 				log('[managed-runtime] background initialization deferred after failure', 'warn', {
 					trigger,
 					code: error instanceof Error && 'code' in error ? String((error as Error & { code?: unknown }).code) : 'initialization-failed',
+					stage: provisioning?.status === 'failed' ? provisioning.failure.stage : 'unknown',
+					attempt: provisioning?.attempt ?? 0,
 				});
 			});
 		};

--- a/src/services/coreFailureClassifier.ts
+++ b/src/services/coreFailureClassifier.ts
@@ -14,6 +14,7 @@ export interface CoreFailureEvidence {
 	message?: string;
 	stdout?: string;
 	stderr?: string;
+	failureDomain?: unknown;
 }
 
 const LOCAL_FALLBACK_FAILURES = new Set<CoreFailureClass>([
@@ -53,6 +54,7 @@ function evidenceFromError(error: unknown, phase: CoreOperationPhase): Required<
 		message: extractErrorMessage(error, candidate, nested),
 		stdout: error instanceof PlatformioProcessError ? error.stdout : String(candidate.stdout ?? ''),
 		stderr: error instanceof PlatformioProcessError ? error.stderr : String(candidate.stderr ?? ''),
+		failureDomain: candidate.failureDomain ?? nested.failureDomain ?? '',
 	};
 }
 
@@ -63,6 +65,7 @@ export function classifyCoreFailure(error: unknown, phase: CoreOperationPhase): 
 	const text = `${evidence.message}\n${evidence.stdout}\n${evidence.stderr}`.toLowerCase();
 
 	if (code === 'ABORT_ERR' || /\b(abort(?:ed)?|cancel(?:led|ed))\b/.test(text)) {return 'cancelled';}
+	if (evidence.failureDomain === 'managed-provisioning') {return 'managed-provisioning';}
 	if (/\b(cert(?:ificate)?|self[- ]signed|unable to verify|tls|ssl)\b/.test(text)) {return 'tls';}
 	if (/\b(proxy|407 proxy authentication)\b/.test(text)) {return 'proxy';}
 	if (code === 'ENOTFOUND' || code === 'EAI_AGAIN' || /\b(dns|name resolution|getaddrinfo)\b/.test(text)) {return 'dns';}
@@ -87,6 +90,7 @@ export function isCoreFallbackAllowed(
 	started: boolean
 ): boolean {
 	if (failureClass === 'cancelled' || phase === 'project-process' && started) {return false;}
+	if (failureClass === 'managed-provisioning') {return phase === 'probe' || phase === 'prepare';}
 	return (phase === 'probe' || phase === 'prepare' || phase === 'project-process') && LOCAL_FALLBACK_FAILURES.has(failureClass);
 }
 

--- a/src/services/managedRuntimeInitializationCoordinator.ts
+++ b/src/services/managedRuntimeInitializationCoordinator.ts
@@ -11,6 +11,7 @@ interface ManagedRuntimeInitializationTarget {
 	getStatus(): Promise<ManagedRuntimeStatus>;
 	ensureReady(options?: {
 		onProgress?: (progress: ManagedRuntimeInstallProgress) => void;
+		trigger?: ManagedRuntimeInitializationTrigger;
 	}): Promise<ManagedRuntimeInstallRecord>;
 }
 
@@ -46,7 +47,7 @@ export class ManagedRuntimeInitializationCoordinator {
 		const status = await this.runtime.getStatus();
 		if (status.status === 'ready') {return { trigger, status: 'already-ready' };}
 		if (status.status === 'unsupported') {return { trigger, status: 'unsupported' };}
-		await this.runtime.ensureReady({ onProgress });
+		await this.runtime.ensureReady({ onProgress, trigger });
 		return { trigger, status: 'installed' };
 	}
 }

--- a/src/services/managedRuntimeInstaller.ts
+++ b/src/services/managedRuntimeInstaller.ts
@@ -4,14 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { ManagedRuntimeDownloader, ManagedRuntimeDownloadResult } from './managedRuntimeDownloader';
 import { extractManagedRuntimeArchive } from './managedRuntimeArchive';
 import { ManagedRuntimeStorage } from './managedRuntimeStorage';
-import { PlatformioProcessOptions, PlatformioProcessResult, runPlatformioProcess } from './platformioProcess';
+import {
+	PlatformioProcessError,
+	PlatformioProcessOptions,
+	PlatformioProcessResult,
+	runPlatformioProcess,
+} from './platformioProcess';
+import { createPlatformioPrivacyRedactor, PlatformioPrivacyRedactor } from './platformioPrivacyRedactor';
 import { sha256 } from './managedRuntimeManifest';
 import {
+	ManagedRuntimeInstallStage,
 	ManagedRuntimeInstallRecord,
 	RuntimeArtifact,
 	RuntimeDownload,
@@ -39,14 +47,33 @@ export interface ManagedRuntimeInstallerOptions {
 }
 
 export interface ManagedRuntimeInstallProgress {
-	stage: 'waiting-lock' | 'downloading-python' | 'extracting-python' | 'installing-platformio' | 'installing-mpremote' | 'verifying' | 'committing';
+	stage: ManagedRuntimeInstallStage;
 	percent: number;
 }
 
 export class ManagedRuntimeInstallerError extends Error {
-	constructor(public readonly code: string, message: string) {
+	readonly failureDomain = 'managed-provisioning' as const;
+	readonly stage: ManagedRuntimeInstallStage;
+	readonly started: boolean;
+	readonly stdout: string;
+	readonly stderr: string;
+
+	constructor(
+		public readonly code: string,
+		message: string,
+		evidence: {
+			stage?: ManagedRuntimeInstallStage;
+			started?: boolean;
+			stdout?: string;
+			stderr?: string;
+		} = {}
+	) {
 		super(message);
 		this.name = 'ManagedRuntimeInstallerError';
+		this.stage = evidence.stage ?? 'waiting-lock';
+		this.started = evidence.started ?? false;
+		this.stdout = evidence.stdout ?? '';
+		this.stderr = evidence.stderr ?? '';
 	}
 }
 
@@ -63,6 +90,7 @@ const LOCK_RECLAIM_RELATIVE_PATH = path.join('locks', 'install.reclaim.lock');
 const LOCK_LEASE_MS = 120_000;
 const LOCK_RENEW_MS = 30_000;
 const LOCK_RECLAIM_LEASE_MS = 30_000;
+const MAX_DIAGNOSTIC_OUTPUT_LENGTH = 4000;
 
 function executableName(name: 'python' | 'pip' | 'pio' | 'mpremote', platform: NodeJS.Platform): string {
 	return platform === 'win32' ? `${name}.exe` : name;
@@ -115,6 +143,7 @@ export class ManagedRuntimeInstaller {
 	private readonly now: () => Date;
 	private readonly createId: () => string;
 	private readonly lockWaitMs: number;
+	private readonly privacyRedactor: PlatformioPrivacyRedactor;
 
 	constructor(options: ManagedRuntimeInstallerOptions) {
 		this.storage = options.storage;
@@ -126,21 +155,31 @@ export class ManagedRuntimeInstaller {
 		this.now = options.now ?? (() => new Date());
 		this.createId = options.createId ?? (() => crypto.randomUUID());
 		this.lockWaitMs = options.lockWaitMs ?? 60_000;
+		this.privacyRedactor = createPlatformioPrivacyRedactor({
+			homeDir: os.homedir(),
+			managedRuntimePath: options.storage.layout.root,
+		});
 	}
 
 	async install(
 		artifact: RuntimeArtifact,
 		options: { signal?: AbortSignal; onProgress?: (progress: ManagedRuntimeInstallProgress) => void } = {}
 	): Promise<ManagedRuntimeInstallRecord> {
-		options.onProgress?.({ stage: 'waiting-lock', percent: 0 });
-		const releaseLock = await this.acquireLock(options.signal);
+		let currentStage: ManagedRuntimeInstallStage = 'waiting-lock';
+		const reportProgress = (stage: ManagedRuntimeInstallStage, percent: number): void => {
+			currentStage = stage;
+			options.onProgress?.({ stage, percent });
+		};
+		reportProgress('waiting-lock', 0);
 		const transactionId = this.createId();
 		const transactionRelative = path.join('staging', transactionId);
-		const versionDirectory = `${this.manifest.runtimeVersion}-${artifact.id}-${transactionId}`;
+		const versionDirectory = transactionId;
 		const runtimeRelative = path.join('versions', versionDirectory);
 		let candidateCreated = false;
 		let currentCommitted = false;
+		let releaseLock: (() => Promise<void>) | undefined;
 		try {
+			releaseLock = await this.acquireLock(options.signal);
 			if (options.signal?.aborted) {
 				throw new ManagedRuntimeInstallerError('cancelled', 'Managed runtime installation was cancelled');
 			}
@@ -151,11 +190,11 @@ export class ManagedRuntimeInstaller {
 				createdAt: this.now().toISOString(),
 			}));
 
-			options.onProgress?.({ stage: 'downloading-python', percent: 5 });
+			reportProgress('downloading-python', 5);
 			const archiveRelative = await this.ensureDownload(artifact, 'tar.gz', options.signal);
 			const installerRelative = await this.ensureDownload(this.manifest.installer, 'py', options.signal);
 
-			options.onProgress?.({ stage: 'extracting-python', percent: 25 });
+			reportProgress('extracting-python', 25);
 			const archivePath = this.storage.files.resolveSafePath(archiveRelative);
 			const runtimePath = this.storage.files.resolveSafePath(runtimeRelative);
 			await this.extractArchive(archivePath, runtimePath);
@@ -187,7 +226,7 @@ export class ManagedRuntimeInstaller {
 				PLATFORMIO_NO_ANSI: 'true',
 			};
 
-			options.onProgress?.({ stage: 'installing-platformio', percent: 40 });
+			reportProgress('installing-platformio', 40);
 			await this.runProcess(
 				bootstrapPython,
 				[this.storage.files.resolveSafePath(installerRelative)],
@@ -201,14 +240,14 @@ export class ManagedRuntimeInstaller {
 				throw new ManagedRuntimeInstallerError('platformio-python-missing', 'PlatformIO installer did not create its managed Python environment');
 			}
 
-			options.onProgress?.({ stage: 'installing-mpremote', percent: 65 });
+			reportProgress('installing-mpremote', 65);
 			await this.runProcess(
 				penvPython,
 				['-m', 'pip', 'install', '--disable-pip-version-check', '--no-input', `mpremote==${this.manifest.mpremoteVersion}`],
 				{ env: runtimeEnvironment, cwd: runtimePath, timeout: 10 * 60_000, signal: options.signal }
 			);
 
-			options.onProgress?.({ stage: 'verifying', percent: 80 });
+			reportProgress('verifying', 80);
 			const probeOptions = { env: runtimeEnvironment, cwd: runtimePath, timeout: 30_000, signal: options.signal };
 			const bootstrapProbe = await this.runProcess(bootstrapPython, ['--version'], probeOptions);
 			const pythonProbe = await this.runProcess(penvPython, ['--version'], probeOptions);
@@ -218,7 +257,7 @@ export class ManagedRuntimeInstaller {
 			await this.runProcess(penvPython, ['-m', 'platformio', 'system', 'info', '--json-output'], probeOptions);
 			const mpremoteProbe = await this.runProcess(penvPython, ['-m', 'mpremote', 'version'], probeOptions);
 
-			options.onProgress?.({ stage: 'committing', percent: 95 });
+			reportProgress('committing', 95);
 			await this.storage.files.writeFileAtomic(path.join(runtimeRelative, '.singular-runtime-owned.json'), JSON.stringify({
 				schemaVersion: 1,
 				runtimeVersion: this.manifest.runtimeVersion,
@@ -243,7 +282,7 @@ export class ManagedRuntimeInstaller {
 			await this.storage.files.writeFileAtomic('current.json', `${JSON.stringify(record, null, 2)}\n`);
 			currentCommitted = true;
 			await this.storage.files.deleteDirectory(transactionRelative).catch(() => undefined);
-			options.onProgress?.({ stage: 'committing', percent: 100 });
+			reportProgress('committing', 100);
 			return record;
 		} catch (error) {
 			if (!currentCommitted && candidateCreated && this.storage.files.fileExists(runtimeRelative)) {
@@ -252,12 +291,31 @@ export class ManagedRuntimeInstaller {
 			if (this.storage.files.fileExists(transactionRelative)) {
 				await this.storage.files.deleteDirectory(transactionRelative).catch(() => undefined);
 			}
-			if (error instanceof ManagedRuntimeInstallerError) {throw error;}
-			const code = (error as NodeJS.ErrnoException).code || 'installation-failed';
-			throw new ManagedRuntimeInstallerError(String(code).toLowerCase(), 'Managed runtime installation did not complete');
+			throw this.toInstallerError(error, currentStage);
 		} finally {
-			await releaseLock().catch(() => undefined);
+			await releaseLock?.().catch(() => undefined);
 		}
+	}
+
+	private toInstallerError(error: unknown, stage: ManagedRuntimeInstallStage): ManagedRuntimeInstallerError {
+		const processError = error instanceof PlatformioProcessError ? error : undefined;
+		const installerError = error instanceof ManagedRuntimeInstallerError ? error : undefined;
+		const candidate = error && typeof error === 'object' ? error as NodeJS.ErrnoException : undefined;
+		const code = installerError?.code ?? processError?.code ?? candidate?.code ?? 'installation-failed';
+		const message = error instanceof Error ? error.message : 'Managed runtime installation did not complete';
+		return new ManagedRuntimeInstallerError(String(code).toLowerCase(), this.sanitizeDiagnosticOutput(message), {
+			stage,
+			started: processError?.started ?? installerError?.started ?? false,
+			stdout: this.sanitizeDiagnosticOutput(processError?.stdout ?? installerError?.stdout ?? ''),
+			stderr: this.sanitizeDiagnosticOutput(processError?.stderr ?? installerError?.stderr ?? ''),
+		});
+	}
+
+	private sanitizeDiagnosticOutput(value: string): string {
+		const withoutControlCharacters = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+		const redacted = this.privacyRedactor.redact(withoutControlCharacters).trim();
+		if (redacted.length <= MAX_DIAGNOSTIC_OUTPUT_LENGTH) {return redacted;}
+		return `[truncated]\n${redacted.slice(-MAX_DIAGNOSTIC_OUTPUT_LENGTH)}`;
 	}
 
 	private async ensureDownload(download: RuntimeDownload, extension: string, signal?: AbortSignal): Promise<string> {

--- a/src/services/managedRuntimeService.ts
+++ b/src/services/managedRuntimeService.ts
@@ -4,18 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as os from 'os';
 import * as path from 'path';
 import { createHash, randomUUID } from 'crypto';
 import { CoreEnvironment } from '../types/coreEnvironment';
 import {
 	ManagedRuntimeInstallRecord,
+	ManagedRuntimeInstallStage,
+	ManagedRuntimeProvisioningFailure,
+	ManagedRuntimeProvisioningState,
+	ManagedRuntimeProvisioningTrigger,
 	ManagedRuntimeStatus,
 	RuntimeArtifact,
 	RuntimeManifest,
 } from '../types/managedRuntime';
-import { ManagedRuntimeInstaller, ManagedRuntimeInstallProgress } from './managedRuntimeInstaller';
+import {
+	ManagedRuntimeInstaller,
+	ManagedRuntimeInstallerError,
+	ManagedRuntimeInstallProgress,
+} from './managedRuntimeInstaller';
 import { selectRuntimeArtifact } from './managedRuntimeManifest';
 import { createWorkspaceStorageKey, ManagedRuntimeStorage } from './managedRuntimeStorage';
+import { createPlatformioPrivacyRedactor, PlatformioPrivacyRedactor } from './platformioPrivacyRedactor';
 
 interface RuntimeInstallerLike {
 	install(
@@ -33,6 +43,7 @@ export interface ManagedRuntimeServiceOptions {
 	arch?: string;
 	libc?: string | null;
 	allowReleaseCandidate?: boolean;
+	now?: () => Date;
 }
 
 export class ManagedRuntimeServiceError extends Error {
@@ -92,7 +103,10 @@ export class ManagedRuntimeService {
 	private readonly arch: string;
 	private readonly libc: string | null;
 	private readonly allowReleaseCandidate: boolean;
-	private ensurePromise?: Promise<ManagedRuntimeInstallRecord>;
+	private readonly now: () => Date;
+	private readonly privacyRedactor: PlatformioPrivacyRedactor;
+	private provisioningPromise?: Promise<ManagedRuntimeInstallRecord>;
+	private provisioningState: ManagedRuntimeProvisioningState = { status: 'idle', attempt: 0 };
 
 	constructor(options: ManagedRuntimeServiceOptions) {
 		this.storage = options.storage;
@@ -107,6 +121,11 @@ export class ManagedRuntimeService {
 		this.arch = options.arch ?? process.arch;
 		this.libc = options.libc === undefined ? detectLibc(this.platform) : options.libc;
 		this.allowReleaseCandidate = options.allowReleaseCandidate ?? false;
+		this.now = options.now ?? (() => new Date());
+		this.privacyRedactor = createPlatformioPrivacyRedactor({
+			homeDir: os.homedir(),
+			managedRuntimePath: options.storage.layout.root,
+		});
 	}
 
 	async getStatus(): Promise<ManagedRuntimeStatus> {
@@ -145,22 +164,31 @@ export class ManagedRuntimeService {
 	async ensureReady(options: {
 		signal?: AbortSignal;
 		onProgress?: (progress: ManagedRuntimeInstallProgress) => void;
+		trigger?: ManagedRuntimeProvisioningTrigger;
 	} = {}): Promise<ManagedRuntimeInstallRecord> {
-		if (this.ensurePromise) {return this.ensurePromise;}
-		this.ensurePromise = this.ensureReadyOnce(options).finally(() => {this.ensurePromise = undefined;});
-		return this.ensurePromise;
+		return this.runSingleProvisioning(() => this.ensureReadyOnce(options));
 	}
 
 	async repair(options: {
 		signal?: AbortSignal;
 		onProgress?: (progress: ManagedRuntimeInstallProgress) => void;
 	} = {}): Promise<ManagedRuntimeInstallRecord> {
-		await this.storage.initialize();
-		const artifact = this.getArtifact();
-		if (!artifact) {
-			throw new ManagedRuntimeServiceError('unsupported-runtime', 'No verified managed runtime is available for this platform');
+		const activeProvisioning = this.provisioningPromise;
+		if (activeProvisioning) {
+			const attempt = this.provisioningState.attempt;
+			if (this.provisioningState.status === 'running') {return activeProvisioning;}
+			try {
+				const record = await activeProvisioning;
+				if (this.provisioningState.attempt > attempt) {return record;}
+			} catch {
+				// An explicit repair may retry after a background readiness check fails.
+			}
 		}
-		return this.installer.install(artifact, options);
+		return this.runSingleProvisioning(() => this.repairOnce(options));
+	}
+
+	getProvisioningState(): ManagedRuntimeProvisioningState {
+		return this.provisioningState;
 	}
 
 	getStorageSummary(): string {
@@ -296,16 +324,98 @@ export class ManagedRuntimeService {
 	private async ensureReadyOnce(options: {
 		signal?: AbortSignal;
 		onProgress?: (progress: ManagedRuntimeInstallProgress) => void;
+		trigger?: ManagedRuntimeProvisioningTrigger;
 	}): Promise<ManagedRuntimeInstallRecord> {
-		await this.storage.initialize();
 		const status = await this.getStatus();
-		if (status.status === 'ready') {return status.record;}
+		if (status.status === 'ready') {
+			this.provisioningState = { status: 'idle', attempt: this.provisioningState.attempt };
+			return status.record;
+		}
 		const artifact = this.getArtifact();
 		if (!artifact) {
 			const reason = status.status === 'missing' ? 'Managed runtime is unsupported' : status.reason;
 			throw new ManagedRuntimeServiceError('unsupported-runtime', reason);
 		}
-		return this.installer.install(artifact, options);
+		return this.runProvisioning(artifact, options.trigger ?? 'workload', options);
+	}
+
+	private async repairOnce(options: {
+		signal?: AbortSignal;
+		onProgress?: (progress: ManagedRuntimeInstallProgress) => void;
+	}): Promise<ManagedRuntimeInstallRecord> {
+		const artifact = this.getArtifact();
+		if (!artifact) {
+			throw new ManagedRuntimeServiceError('unsupported-runtime', 'No verified managed runtime is available for this platform');
+		}
+		return this.runProvisioning(artifact, 'repair', options);
+	}
+
+	private runSingleProvisioning(
+		operation: () => Promise<ManagedRuntimeInstallRecord>
+	): Promise<ManagedRuntimeInstallRecord> {
+		if (this.provisioningPromise) {return this.provisioningPromise;}
+		this.provisioningPromise = operation().finally(() => {this.provisioningPromise = undefined;});
+		return this.provisioningPromise;
+	}
+
+	private async runProvisioning(
+		artifact: RuntimeArtifact,
+		trigger: ManagedRuntimeProvisioningTrigger,
+		options: { signal?: AbortSignal; onProgress?: (progress: ManagedRuntimeInstallProgress) => void }
+	): Promise<ManagedRuntimeInstallRecord> {
+		const attempt = this.provisioningState.attempt + 1;
+		const startedAt = this.now().toISOString();
+		let stage: ManagedRuntimeInstallStage = 'waiting-lock';
+		let percent = 0;
+		this.provisioningState = { status: 'running', attempt, trigger, stage, percent, startedAt, updatedAt: startedAt };
+		try {
+			await this.storage.initialize();
+			const record = await this.installer.install(artifact, {
+				signal: options.signal,
+				onProgress: progress => {
+					stage = progress.stage;
+					percent = progress.percent;
+					this.provisioningState = {
+						status: 'running', attempt, trigger, stage, percent, startedAt, updatedAt: this.now().toISOString(),
+					};
+					options.onProgress?.(progress);
+				},
+			});
+			this.provisioningState = { status: 'idle', attempt };
+			return record;
+		} catch (error) {
+			const failure = this.createProvisioningFailure(error, stage);
+			this.provisioningState = {
+				status: 'failed', attempt, trigger, stage: failure.stage, percent, startedAt,
+				failedAt: this.now().toISOString(), failure,
+			};
+			if (error instanceof ManagedRuntimeInstallerError) {throw error;}
+			throw new ManagedRuntimeInstallerError(failure.code, failure.message, failure);
+		}
+	}
+
+	private createProvisioningFailure(
+		error: unknown,
+		stage: ManagedRuntimeInstallStage
+	): ManagedRuntimeProvisioningFailure {
+		const installerError = error instanceof ManagedRuntimeInstallerError ? error : undefined;
+		const candidate = error && typeof error === 'object' ? error as NodeJS.ErrnoException : undefined;
+		return {
+			failureDomain: 'managed-provisioning',
+			stage: installerError?.stage ?? stage,
+			code: String(installerError?.code ?? candidate?.code ?? 'installation-failed').toLowerCase(),
+			started: installerError?.started ?? false,
+			message: this.sanitizeProvisioningEvidence(error instanceof Error ? error.message : String(error)),
+			stdout: this.sanitizeProvisioningEvidence(installerError?.stdout ?? ''),
+			stderr: this.sanitizeProvisioningEvidence(installerError?.stderr ?? ''),
+		};
+	}
+
+	private sanitizeProvisioningEvidence(value: string): string {
+		const redacted = this.privacyRedactor.redact(value)
+			.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+			.trim();
+		return redacted.length <= 4000 ? redacted : `[truncated]\n${redacted.slice(-4000)}`;
 	}
 
 	private getArtifact(): RuntimeArtifact | null {

--- a/src/services/platformioAiRepairPacketService.ts
+++ b/src/services/platformioAiRepairPacketService.ts
@@ -12,6 +12,8 @@ import {
 	PlatformioDiagnosticSession,
 	RepairHistorySummary,
 } from '../types/platformioDiagnostic';
+import type { WorkloadSelection } from '../types/coreEnvironment';
+import type { ManagedRuntimeProvisioningState } from '../types/managedRuntime';
 
 export interface PlatformioAiRepairPacketServiceOptions {
 	now?: () => Date;
@@ -148,15 +150,30 @@ export class PlatformioAiRepairPacketService {
 			return ['- Provider Core: readiness unknown', '- Singular managed Core: readiness unknown'];
 		}
 		const { provider, managed } = diagnostics.environments;
-		return [
+		const lines = [
 			`- Provider Core: ${provider.status}; version=${provider.version ?? 'unknown'}; ${provider.reason}`,
 			`- Singular managed Core: ${managed.status}; version=${managed.version ?? 'unknown'}; storage=${managed.storageSummary ?? 'unknown'}; ${managed.reason}`,
 			`- Arduino route: ${this.formatSelection(diagnostics.selection.arduino)}`,
 			`- Python route: ${this.formatSelection(diagnostics.selection.python)}`,
 		];
+		lines.push(...this.formatProvisioning(managed.provisioning));
+		return lines;
 	}
 
-	private formatSelection(selection: import('../types/coreEnvironment').WorkloadSelection): string {
+	private formatProvisioning(state: ManagedRuntimeProvisioningState | undefined): string[] {
+		if (!state || state.status === 'idle') {return [];}
+		if (state.status === 'running') {
+			return [`- Managed provisioning: running; attempt=${state.attempt}; trigger=${state.trigger}; stage=${state.stage}; percent=${state.percent}`];
+		}
+		const lines = [
+			`- Managed provisioning: failed; attempt=${state.attempt}; trigger=${state.trigger}; stage=${state.failure.stage}; code=${state.failure.code}; started=${state.failure.started}`,
+		];
+		if (state.failure.stdout) {lines.push(`- Managed installer stdout: ${state.failure.stdout}`);}
+		if (state.failure.stderr) {lines.push(`- Managed installer stderr: ${state.failure.stderr}`);}
+		return lines;
+	}
+
+	private formatSelection(selection: WorkloadSelection): string {
 		return `${selection.primary} -> ${selection.fallback}; selected=${selection.selected ?? 'none'}; fallbackUsed=${selection.fallbackUsed}`;
 	}
 
@@ -182,11 +199,15 @@ export class PlatformioAiRepairPacketService {
 
 	private buildCurrentBlocker(session: PlatformioDiagnosticSession): string {
 		const blocker = session.items.find(item => item.status === 'error') ?? session.items.find(item => item.status === 'warning');
-		if (!blocker) {
-			return 'No current blocker detected; diagnostics are operational.';
+		if (blocker) {return `${blocker.id}: ${blocker.reason}${blocker.nextStep ? ` Next step: ${blocker.nextStep}` : ''}`;}
+		const managed = session.coreDiagnostics?.environments.managed;
+		if (managed?.provisioning?.status === 'running') {
+			return `managed-runtime: provisioning is active at ${managed.provisioning.stage} (${managed.provisioning.percent}%).`;
 		}
-
-		return `${blocker.id}: ${blocker.reason}${blocker.nextStep ? ` Next step: ${blocker.nextStep}` : ''}`;
+		if (managed?.provisioning?.status === 'failed') {
+			return `managed-runtime: ${managed.reason}`;
+		}
+		return 'No current blocker detected; diagnostics are operational.';
 	}
 
 	private formatUnknown(value: boolean | undefined): string {

--- a/src/services/platformioDiagnosticService.ts
+++ b/src/services/platformioDiagnosticService.ts
@@ -30,12 +30,13 @@ import {
 	OfficialPlatformioSettingsEvidence,
 	PanelActionId,
 	PlatformioDiagnosticItem,
+	CoreDiagnosticEnvironment,
 	PlatformioDiagnosticPanelState,
 	PlatformioDiagnosticSession,
 	PlatformioOverallStatus,
 	VersionProbeResult,
 } from '../types/platformioDiagnostic';
-import { ManagedRuntimeStatus } from '../types/managedRuntime';
+import { ManagedRuntimeProvisioningState, ManagedRuntimeStatus } from '../types/managedRuntime';
 import { CoreWorkload, WorkloadSelection } from '../types/coreEnvironment';
 
 interface MessageLocalizer {
@@ -65,6 +66,7 @@ export interface PlatformioDiagnosticServiceOptions {
 		getStatus(): Promise<ManagedRuntimeStatus>;
 		getStorageSummary(): string;
 		getStorageUsageBytes(): Promise<number | null>;
+		getProvisioningState?(): ManagedRuntimeProvisioningState;
 	};
 	coreEnvironmentManager?: {
 		getSelection(workload: CoreWorkload, workspaceUri: string): WorkloadSelection;
@@ -248,11 +250,17 @@ export class PlatformioDiagnosticService {
 		}
 
 		const items: PlatformioDiagnosticSession['items'] = [pioItem, penvRootItem, pythonItem, pipItem, mpremoteItem];
-		const overallStatus = this.getOverallStatus(items);
+		let overallStatus = this.getOverallStatus(items);
 		const scopeNotice = await this.message(
 			'PLATFORMIO_DIAGNOSTIC_SCOPE_NOTICE',
 			'This report reflects the VS Code extension runtime on this machine. It may differ from the shell environment you use in an external terminal.'
 		);
+
+		const coreDiagnostics = await this.buildCoreDiagnostics(pioItem, workspacePath ?? '');
+		const provisioningStatus = coreDiagnostics.environments.managed.provisioning?.status;
+		if (overallStatus === 'operational' && (provisioningStatus === 'running' || provisioningStatus === 'failed')) {
+			overallStatus = 'degraded';
+		}
 
 		const session: PlatformioDiagnosticSession = {
 			sessionId: requestedAt,
@@ -267,8 +275,8 @@ export class PlatformioDiagnosticService {
 				arch: process.arch,
 				pathSeparator: this.platform === 'win32' ? ';' : ':',
 			},
+			coreDiagnostics,
 		};
-		session.coreDiagnostics = await this.buildCoreDiagnostics(pioItem, workspacePath ?? '');
 
 		log('[platformio-diagnostic] diagnostic collection completed', 'info', {
 			overallStatus,
@@ -291,29 +299,8 @@ export class PlatformioDiagnosticService {
 		}
 		const managedStatus = this.managedRuntime ? await this.managedRuntime.getStatus() : { status: 'missing' } as const;
 		const managedStorageUsage = this.managedRuntime ? await this.managedRuntime.getStorageUsageBytes() : null;
-		const managed = managedStatus.status === 'ready'
-			? {
-				id: 'managed' as const,
-				status: 'healthy' as const,
-				version: managedStatus.record.tools.pio.version,
-				storageSummary: this.managedRuntime?.getStorageSummary() ?? null,
-				storageUsageBytes: managedStorageUsage,
-				packageStatus: 'unknown' as const,
-				failureClass: null,
-				reason: 'Managed runtime is installed and passed its local health checks.',
-			}
-			: {
-				id: 'managed' as const,
-				status: managedStatus.status === 'invalid' ? 'degraded' as const : 'unavailable' as const,
-				version: null,
-				storageSummary: this.managedRuntime?.getStorageSummary() ?? null,
-				storageUsageBytes: managedStorageUsage,
-				packageStatus: 'unknown' as const,
-				failureClass: managedStatus.status === 'invalid' ? 'local-store-corruption' as const : 'missing-executable' as const,
-				reason: managedStatus.status === 'missing'
-					? 'Managed runtime is not installed. Diagnostics did not start an installation.'
-					: managedStatus.reason,
-			};
+		const provisioning = this.managedRuntime?.getProvisioningState?.() ?? { status: 'idle', attempt: 0 };
+		const managed = this.buildManagedDiagnosticEnvironment(managedStatus, managedStorageUsage, provisioning);
 
 		return {
 			environments: {
@@ -333,6 +320,65 @@ export class PlatformioDiagnosticService {
 				arduino: this.getWorkloadSelection('arduino', workspaceUri),
 				python: this.getWorkloadSelection('python', workspaceUri),
 			},
+		};
+	}
+
+	private buildManagedDiagnosticEnvironment(
+		status: ManagedRuntimeStatus,
+		storageUsageBytes: number | null,
+		provisioning: ManagedRuntimeProvisioningState
+	): CoreDiagnosticEnvironment {
+		const base = {
+			id: 'managed' as const,
+			storageSummary: this.managedRuntime?.getStorageSummary() ?? null,
+			storageUsageBytes,
+			packageStatus: 'unknown' as const,
+			provisioning,
+		};
+		if (status.status === 'ready') {
+			return {
+				...base,
+				status: 'healthy',
+				version: status.record.tools.pio.version,
+				failureClass: null,
+				reason: 'Managed runtime is installed and passed its local health checks.',
+			};
+		}
+		if (provisioning.status === 'running') {
+			return {
+				...base,
+				status: 'unavailable',
+				version: null,
+				failureClass: 'managed-provisioning',
+				reason: `Managed runtime provisioning is active at ${provisioning.stage} (${provisioning.percent}%).`,
+			};
+		}
+		if (provisioning.status === 'failed') {
+			return {
+				...base,
+				status: 'unavailable',
+				version: null,
+				failureClass: 'managed-provisioning',
+				reason: `Managed runtime provisioning failed at ${provisioning.stage} (code ${provisioning.failure.code}). ${provisioning.failure.message}`,
+			};
+		}
+		if (status.status === 'invalid') {
+			return {
+				...base,
+				status: 'degraded',
+				version: null,
+				failureClass: 'local-store-corruption',
+				reason: status.reason,
+			};
+		}
+		return {
+			...base,
+			status: 'unavailable',
+			version: null,
+			failureClass: 'missing-executable',
+			reason: status.status === 'missing'
+				? 'Managed runtime is not installed. Diagnostics did not start an installation.'
+				: status.reason,
 		};
 	}
 
@@ -438,6 +484,15 @@ export class PlatformioDiagnosticService {
 				lines.push(`  Storage usage: ${environment.storageUsageBytes === null ? '-' : `${environment.storageUsageBytes} bytes`}`);
 				lines.push(`  Package status: ${environment.packageStatus}`);
 				lines.push(`  Reason: ${environment.reason}`);
+				if (environment.provisioning?.status === 'running') {
+					lines.push(`  Provisioning: running; attempt=${environment.provisioning.attempt}; trigger=${environment.provisioning.trigger}; stage=${environment.provisioning.stage}; percent=${environment.provisioning.percent}`);
+				}
+				if (environment.provisioning?.status === 'failed') {
+					const failure = environment.provisioning.failure;
+					lines.push(`  Provisioning: failed; attempt=${environment.provisioning.attempt}; trigger=${environment.provisioning.trigger}; stage=${failure.stage}; code=${failure.code}; started=${failure.started}`);
+					if (failure.stdout) {lines.push(`  Installer stdout: ${failure.stdout}`);}
+					if (failure.stderr) {lines.push(`  Installer stderr: ${failure.stderr}`);}
+				}
 			}
 			for (const workload of ['arduino', 'python'] as const) {
 				const selection = session.coreDiagnostics.selection[workload];

--- a/src/services/platformioIssueDraftService.ts
+++ b/src/services/platformioIssueDraftService.ts
@@ -9,7 +9,6 @@ import { formatPlatformioDiagnosticFinding } from './platformioDiagnosticFormatt
 import * as os from 'os';
 import {
 	IssueDraftProposal,
-	PlatformioDiagnosticItem,
 	PlatformioDiagnosticSession,
 	RepairHistorySummary,
 } from '../types/platformioDiagnostic';
@@ -54,7 +53,7 @@ export class PlatformioIssueDraftService {
 		];
 		const duplicateSearchHints = this.buildDuplicateSearchHints(input.session);
 
-		if (input.session.overallStatus === 'operational') {
+		if (input.session.overallStatus === 'operational' && !this.hasManagedProvisioningBlocker(input.session)) {
 			return {
 				title: 'No PlatformIO issue draft recommended',
 				body: 'No issue draft recommended: diagnostics are operational.',
@@ -127,12 +126,27 @@ export class PlatformioIssueDraftService {
 			const selection = diagnostics.selection[workload];
 			return `${selection.primary} -> ${selection.fallback}; selected=${selection.selected ?? 'none'}; fallbackUsed=${selection.fallbackUsed}`;
 		};
-		return [
+		const lines = [
 			`- Provider Core: ${provider.status}; version=${provider.version ?? 'unknown'}; ${provider.reason}`,
 			`- Singular managed Core: ${managed.status}; version=${managed.version ?? 'unknown'}; storage=${managed.storageSummary ?? 'unknown'}; ${managed.reason}`,
 			`- Arduino route: ${route('arduino')}`,
 			`- Python route: ${route('python')}`,
 		];
+		const provisioning = managed.provisioning;
+		if (provisioning?.status === 'running') {
+			lines.push(`- Managed provisioning: running; attempt=${provisioning.attempt}; trigger=${provisioning.trigger}; stage=${provisioning.stage}; percent=${provisioning.percent}`);
+		}
+		if (provisioning?.status === 'failed') {
+			const failure = provisioning.failure;
+			lines.push(`- Managed provisioning: failed; attempt=${provisioning.attempt}; trigger=${provisioning.trigger}; stage=${failure.stage}; code=${failure.code}; started=${failure.started}`);
+			if (failure.stdout) {lines.push(`- Managed installer stdout: ${failure.stdout}`);}
+			if (failure.stderr) {lines.push(`- Managed installer stderr: ${failure.stderr}`);}
+		}
+		return lines;
+	}
+
+	private hasManagedProvisioningBlocker(session: PlatformioDiagnosticSession): boolean {
+		return this.findManagedProvisioningBlocker(session) !== undefined;
 	}
 
 	private createRedactor(sessionWorkspacePath?: string | null): PlatformioPrivacyRedactor {
@@ -142,8 +156,29 @@ export class PlatformioIssueDraftService {
 		}, sessionWorkspacePath);
 	}
 
-	private findBlocker(session: PlatformioDiagnosticSession): PlatformioDiagnosticItem | undefined {
-		return session.items.find(item => item.status === 'error') ?? session.items.find(item => item.status === 'warning');
+	private findBlocker(session: PlatformioDiagnosticSession): { id: string; reason: string } | undefined {
+		return this.findManagedProvisioningBlocker(session)
+			?? session.items.find(item => item.status === 'error')
+			?? session.items.find(item => item.status === 'warning');
+	}
+
+	private findManagedProvisioningBlocker(
+		session: PlatformioDiagnosticSession
+	): { id: string; reason: string } | undefined {
+		const provisioning = session.coreDiagnostics?.environments.managed.provisioning;
+		if (provisioning?.status === 'running') {
+			return {
+				id: 'managed-provisioning',
+				reason: `attempt ${provisioning.attempt} is running at ${provisioning.stage} (${provisioning.percent}%)`,
+			};
+		}
+		if (provisioning?.status === 'failed') {
+			return {
+				id: 'managed-provisioning',
+				reason: `attempt ${provisioning.attempt} failed at ${provisioning.failure.stage}: ${provisioning.failure.message}`,
+			};
+		}
+		return undefined;
 	}
 
 	private buildDuplicateSearchHints(session: PlatformioDiagnosticSession): string[] {

--- a/src/services/platformioPrivacyRedactor.ts
+++ b/src/services/platformioPrivacyRedactor.ts
@@ -7,6 +7,7 @@
 export interface PlatformioPrivacyRedactorOptions {
 	homeDir?: string;
 	workspacePath?: string | null;
+	managedRuntimePath?: string | null;
 }
 
 export class PlatformioPrivacyRedactor {
@@ -15,6 +16,7 @@ export class PlatformioPrivacyRedactor {
 	redact(value: string): string {
 		let redacted = value;
 		redacted = this.redactPath(redacted, this.options.workspacePath, '<workspace>');
+		redacted = this.redactPath(redacted, this.options.managedRuntimePath, '<managed-runtime>');
 		redacted = this.redactPath(redacted, this.options.homeDir, '<home>');
 		redacted = this.redactProxyCredentials(redacted);
 		redacted = this.redactTokenLikeStrings(redacted);
@@ -28,14 +30,15 @@ export class PlatformioPrivacyRedactor {
 
 		const variants = this.createPathVariants(rawPath.trim());
 		return variants.reduce((current, variant) => {
-			return current.replace(new RegExp(this.escapeRegExp(variant), 'g'), replacement);
+			return current.replace(new RegExp(this.escapeRegExp(variant), 'gi'), replacement);
 		}, value);
 	}
 
 	private createPathVariants(rawPath: string): string[] {
 		const slashVariant = rawPath.replace(/\\/g, '/');
 		const backslashVariant = rawPath.replace(/\//g, '\\');
-		return [...new Set([rawPath, slashVariant, backslashVariant])].filter(variant => variant.length > 0);
+		return [...new Set([rawPath, slashVariant, backslashVariant, encodeURI(slashVariant)])]
+			.filter(variant => variant.length > 0);
 	}
 
 	private redactProxyCredentials(value: string): string {
@@ -63,5 +66,6 @@ export function createPlatformioPrivacyRedactor(
 	return new PlatformioPrivacyRedactor({
 		homeDir: options.homeDir,
 		workspacePath: options.workspacePath ?? sessionWorkspacePath,
+		managedRuntimePath: options.managedRuntimePath,
 	});
 }

--- a/src/test/services/coreEnvironmentManager.test.ts
+++ b/src/test/services/coreEnvironmentManager.test.ts
@@ -65,6 +65,24 @@ suite('CoreEnvironmentManager', () => {
 		}
 	});
 
+	test('uses a healthy provider when managed provisioning fails before a Python workload starts', async () => {
+		const calls: string[] = [];
+		const provisioningError = Object.assign(new Error('managed installer exited with code 1'), {
+			failureDomain: 'managed-provisioning', started: true, code: 1,
+		});
+		const manager = new CoreEnvironmentManager(
+			fakeProvider('provider', calls, async () => environment('provider')),
+			fakeProvider('managed', calls, async () => {throw provisioningError;})
+		);
+
+		const result = await manager.getEnvironment('python', 'file:///workspace');
+
+		assert.strictEqual(result.selected?.id, 'provider');
+		assert.strictEqual(result.fallbackUsed, true);
+		assert.deepStrictEqual(calls, ['managed', 'provider']);
+		assert.strictEqual(manager.getSelection('python', 'file:///workspace').stickyReason, 'managed-provisioning');
+	});
+
 	test('retries a pre-start local operation failure with the other Core and makes it sticky', async () => {
 		const calls: string[] = [];
 		const operations: string[] = [];

--- a/src/test/services/coreFailureClassifier.test.ts
+++ b/src/test/services/coreFailureClassifier.test.ts
@@ -14,6 +14,7 @@ suite('Core failure classifier', () => {
 		['python-import', new Error("ModuleNotFoundError: No module named 'platformio'"), 'prepare'],
 		['permission', Object.assign(new Error('permission denied'), { code: 'EACCES' }), 'prepare'],
 		['local-store-corruption', new Error('corrupt local core metadata'), 'prepare'],
+		['managed-provisioning', Object.assign(new Error('managed installer failed'), { failureDomain: 'managed-provisioning', started: true, code: 1 }), 'probe'],
 		['compile', new Error('main.cpp:2: error: missing symbol'), 'project-process'],
 		['project-config', new Error('Invalid project configuration in platformio.ini'), 'project-process'],
 		['dns', Object.assign(new Error('getaddrinfo failed'), { code: 'ENOTFOUND' }), 'prepare'],
@@ -34,6 +35,9 @@ suite('Core failure classifier', () => {
 			assert.strictEqual(isCoreFallbackAllowed(failure, 'prepare', false), true);
 			assert.strictEqual(isCoreFallbackAllowed(failure, 'project-process', true), false);
 		}
+		assert.strictEqual(isCoreFallbackAllowed('managed-provisioning', 'probe', true), true);
+		assert.strictEqual(isCoreFallbackAllowed('managed-provisioning', 'prepare', true), true);
+		assert.strictEqual(isCoreFallbackAllowed('managed-provisioning', 'project-process', false), false);
 		for (const failure of ['compile', 'project-config', 'dns', 'proxy', 'tls', 'registry', 'device', 'serial', 'cancelled', 'unknown-after-start'] as const) {
 			assert.strictEqual(isCoreFallbackAllowed(failure, 'prepare', false), false);
 		}
@@ -58,5 +62,14 @@ suite('Core failure classifier', () => {
 	test('allows a local prepare failure after the preflight process starts', () => {
 		assert.strictEqual(isCoreFallbackAllowed('python-import', 'prepare', true), true);
 		assert.strictEqual(isCoreFallbackAllowed('python-import', 'project-process', true), false);
+	});
+
+	test('keeps cancellation fail-closed even when provisioning evidence is present', () => {
+		const error = Object.assign(new Error('Managed runtime installation was cancelled'), {
+			failureDomain: 'managed-provisioning', code: 'ABORT_ERR', started: true,
+		});
+		const failure = classifyCoreFailure(error, 'probe');
+		assert.strictEqual(failure, 'cancelled');
+		assert.strictEqual(isCoreFallbackAllowed(failure, 'probe', true), false);
 	});
 });

--- a/src/test/services/managedRuntimeInstaller.test.ts
+++ b/src/test/services/managedRuntimeInstaller.test.ts
@@ -124,6 +124,7 @@ suite('ManagedRuntime Installer', () => {
 
 		assert.strictEqual(record.health.status, 'healthy');
 		assert.strictEqual(record.artifactId, artifact.id);
+		assert.strictEqual(record.versionDirectory, 'transaction-id', 'Immutable version directories should not repeat long manifest identifiers');
 		assert.ok(fs.existsSync(path.join(storage.layout.versions, record.versionDirectory, record.tools.pio.relativePath)));
 		assert.deepStrictEqual(JSON.parse(fs.readFileSync(storage.layout.currentRecord, 'utf8')), record);
 		assert.ok(processCalls.some(call => call.args.includes(`mpremote==${manifest.mpremoteVersion}`)));
@@ -143,6 +144,36 @@ suite('ManagedRuntime Installer', () => {
 		await assert.rejects(() => new ManagedRuntimeInstaller(failing).install(artifact), ManagedRuntimeInstallerError);
 		assert.strictEqual(JSON.parse(fs.readFileSync(storage.layout.currentRecord, 'utf8')).versionDirectory, first.versionDirectory);
 		assert.ok(!fs.existsSync(path.join(storage.layout.staging, 'failed-update')));
+	});
+
+	test('preserves redacted subprocess evidence and the failing installer stage', async () => {
+		const token = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD';
+		const options = createOptions({
+			runProcess: async () => {
+				throw new PlatformioProcessError(
+					`installer failed under ${storage.layout.root}`,
+					true,
+					1,
+					`stdout token=${token}`,
+					`stderr path=${storage.layout.root}`
+				);
+			},
+		});
+
+		await assert.rejects(
+			() => new ManagedRuntimeInstaller(options).install(artifact),
+			(error: unknown) => {
+				if (!(error instanceof ManagedRuntimeInstallerError)) {return false;}
+				assert.strictEqual(error.failureDomain, 'managed-provisioning');
+				assert.strictEqual(error.stage, 'installing-platformio');
+				assert.strictEqual(error.started, true);
+				assert.strictEqual(error.code, '1');
+				assert.ok(error.stderr.includes('<managed-runtime>'));
+				assert.ok(!`${error.message}\n${error.stdout}\n${error.stderr}`.includes(storage.layout.root));
+				assert.ok(!error.stdout.includes(token));
+				return true;
+			}
+		);
 	});
 
 	test('does not create a ready record after ENOSPC', async () => {

--- a/src/test/services/managedRuntimeService.test.ts
+++ b/src/test/services/managedRuntimeService.test.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { ManagedRuntimeService, ManagedRuntimeServiceError } from '../../services/managedRuntimeService';
+import { ManagedRuntimeInstallerError } from '../../services/managedRuntimeInstaller';
 import { ManagedRuntimeStorage } from '../../services/managedRuntimeStorage';
 import { ManagedRuntimeInstallRecord, RuntimeArtifact, RuntimeManifest } from '../../types/managedRuntime';
 
@@ -91,6 +92,117 @@ suite('ManagedRuntime Service', () => {
 
 		assert.strictEqual(first.versionDirectory, second.versionDirectory);
 		assert.strictEqual(installCalls, 1);
+	});
+
+	test('shares one provisioning transaction between concurrent ensure and repair', async () => {
+		const service = createService();
+		const [ensured, repaired] = await Promise.all([service.ensureReady(), service.repair()]);
+
+		assert.strictEqual(ensured.versionDirectory, repaired.versionDirectory);
+		assert.strictEqual(installCalls, 1);
+	});
+
+	test('does not swallow an explicit repair behind a ready-state check', async () => {
+		await writeInstalledRecord();
+		const repairedRecord = createRecord('repaired-v2');
+		const service = createService(repairedRecord);
+
+		const [ensured, repaired] = await Promise.all([service.ensureReady(), service.repair()]);
+
+		assert.strictEqual(ensured.versionDirectory, 'installed-v1');
+		assert.strictEqual(repaired.versionDirectory, 'repaired-v2');
+		assert.strictEqual(installCalls, 1);
+	});
+
+	test('exposes an in-flight background provisioning stage without starting another attempt', async () => {
+		const record = createRecord();
+		let finishInstallation: (() => void) | undefined;
+		let markInstallationStarted: (() => void) | undefined;
+		const installationStarted = new Promise<void>(resolve => {markInstallationStarted = resolve;});
+		const service = new ManagedRuntimeService({
+			storage, manifest, manifestSha256, platform: 'linux', arch: 'x64', libc: 'glibc',
+			now: () => new Date('2026-08-17T04:00:00.000Z'),
+			installer: {
+				install: async (_artifact, options) => {
+					options?.onProgress?.({ stage: 'installing-platformio', percent: 40 });
+					markInstallationStarted?.();
+					await new Promise<void>(resolve => {finishInstallation = resolve;});
+					return record;
+				},
+			},
+		});
+
+		const installation = service.ensureReady({ trigger: 'activation' });
+		await installationStarted;
+		const running = service.getProvisioningState();
+		assert.strictEqual(running.status, 'running');
+		if (running.status === 'running') {
+			assert.strictEqual(running.trigger, 'activation');
+			assert.strictEqual(running.stage, 'installing-platformio');
+			assert.strictEqual(running.percent, 40);
+		}
+		finishInstallation?.();
+		await installation;
+		assert.deepStrictEqual(service.getProvisioningState(), { status: 'idle', attempt: 1 });
+	});
+
+	test('records storage initialization failures as the first provisioning stage', async () => {
+		let installerCalled = false;
+		storage.initialize = async () => {
+			throw Object.assign(new Error(`permission denied at ${storage.layout.root}`), { code: 'EACCES' });
+		};
+		const service = new ManagedRuntimeService({
+			storage, manifest, manifestSha256, platform: 'linux', arch: 'x64', libc: 'glibc',
+			now: () => new Date('2026-08-17T04:00:00.000Z'),
+			installer: { install: async () => {installerCalled = true; return createRecord();} },
+		});
+
+		await assert.rejects(
+			() => service.ensureReady({ trigger: 'editor-open' }),
+			(error: unknown) => error instanceof ManagedRuntimeInstallerError &&
+				error.failureDomain === 'managed-provisioning' &&
+				error.code === 'eacces' &&
+				!error.message.includes(storage.layout.root)
+		);
+
+		assert.strictEqual(installerCalled, false);
+		const failed = service.getProvisioningState();
+		assert.strictEqual(failed.status, 'failed');
+		if (failed.status === 'failed') {
+			assert.strictEqual(failed.attempt, 1);
+			assert.strictEqual(failed.trigger, 'editor-open');
+			assert.strictEqual(failed.failure.stage, 'waiting-lock');
+			assert.strictEqual(failed.failure.code, 'eacces');
+			assert.ok(!failed.failure.message.includes(storage.layout.root));
+		}
+	});
+
+	test('retains only privacy-redacted evidence after provisioning fails', async () => {
+		const token = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD';
+		const service = new ManagedRuntimeService({
+			storage, manifest, manifestSha256, platform: 'linux', arch: 'x64', libc: 'glibc',
+			now: () => new Date('2026-08-17T04:00:00.000Z'),
+			installer: {
+				install: async (_artifact, options) => {
+					options?.onProgress?.({ stage: 'installing-platformio', percent: 40 });
+					throw new ManagedRuntimeInstallerError(`1`, `failed under ${storage.layout.root}`, {
+						stage: 'installing-platformio', started: true,
+						stdout: `token=${token}`, stderr: `path=${storage.layout.root}`,
+					});
+				},
+			},
+		});
+
+		await assert.rejects(() => service.ensureReady({ trigger: 'activation' }));
+		const failed = service.getProvisioningState();
+		assert.strictEqual(failed.status, 'failed');
+		if (failed.status === 'failed') {
+			assert.strictEqual(failed.failure.stage, 'installing-platformio');
+			assert.strictEqual(failed.failure.started, true);
+			assert.ok(failed.failure.stderr.includes('<managed-runtime>'));
+			assert.ok(!JSON.stringify(failed).includes(storage.layout.root));
+			assert.ok(!JSON.stringify(failed).includes(token));
+		}
 	});
 
 	test('reuses a valid current record without any download or install', async () => {

--- a/src/test/services/platformioAiRepairPacketService.test.ts
+++ b/src/test/services/platformioAiRepairPacketService.test.ts
@@ -124,6 +124,30 @@ suite('PlatformioAiRepairPacketService Tests', () => {
 		assert.ok(!packet.plainText.includes('/tmp/secret-workspace'));
 		assert.ok(packet.plainText.includes('<workspace>'));
 	});
+
+	test('includes managed provisioning evidence as the current blocker with privacy redaction', () => {
+		const service = new PlatformioAiRepairPacketService({ homeDir: '/Users/alice' });
+		const coreDiagnostics = createCoreDiagnostics();
+		coreDiagnostics.environments.managed.provisioning = {
+			status: 'failed', attempt: 3, trigger: 'activation', stage: 'installing-platformio', percent: 40,
+			startedAt: '2026-01-02T03:00:00.000Z', failedAt: '2026-01-02T03:01:00.000Z',
+			failure: {
+				failureDomain: 'managed-provisioning', stage: 'installing-platformio', code: '1', started: true,
+				message: 'installer failed', stdout: '',
+				stderr: '/Users/alice/runtime token=ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD',
+			},
+		};
+		const session = createDiagnosticSession({ overallStatus: 'operational', coreDiagnostics });
+
+		const packet = service.buildPacket({ session });
+
+		assert.ok(packet.currentBlocker.includes('managed-runtime'));
+		assert.ok(packet.plainText.includes('Managed installer stderr'));
+		assert.ok(packet.plainText.includes('<home>'));
+		assert.ok(!packet.plainText.includes('/Users/alice'));
+		assert.ok(!packet.plainText.includes('ghp_'));
+		assert.ok(!packet.currentBlocker.includes('No current blocker'));
+	});
 });
 
 function createCoreDiagnostics(): NonNullable<ReturnType<typeof createDiagnosticSession>['coreDiagnostics']> {

--- a/src/test/services/platformioDiagnosticService.test.ts
+++ b/src/test/services/platformioDiagnosticService.test.ts
@@ -7,6 +7,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { PlatformioDiagnosticService } from '../../services/platformioDiagnosticService';
+import type { ManagedRuntimeProvisioningState } from '../../types/managedRuntime';
 
 interface StubLocaleService {
 	getLocalizedMessage(key: string, fallbackOrArg?: string | any, ...args: any[]): Promise<string>;
@@ -410,6 +411,56 @@ suite('PlatformioDiagnosticService Tests', () => {
 		assert.strictEqual(session.coreDiagnostics?.environments.managed.storageUsageBytes, 4096);
 		assert.strictEqual(session.coreDiagnostics?.selection.arduino.selected, 'managed');
 		assert.strictEqual(session.coreDiagnostics?.selection.python.selected, 'provider');
+	});
+
+	test('reports active and failed managed provisioning as a diagnostic blocker', async () => {
+		const availablePaths = new Set([
+			'/custom/penv/bin/pio', '/custom/penv', '/custom/penv/bin/python3',
+			'/custom/penv/bin/pip3', '/custom/penv/bin/mpremote',
+		]);
+		existsSyncStub.callsFake(filePath => availablePaths.has(filePath));
+		execFileStub.resolves({ stdout: 'PlatformIO Core, version 6.1.19', stderr: '' });
+		let provisioning: ManagedRuntimeProvisioningState = {
+			status: 'failed' as const,
+			attempt: 3,
+			trigger: 'activation' as const,
+			stage: 'installing-platformio' as const,
+			percent: 40,
+			startedAt: now.toISOString(),
+			failedAt: now.toISOString(),
+			failure: {
+				failureDomain: 'managed-provisioning' as const,
+				stage: 'installing-platformio' as const,
+				code: '1', started: true, message: 'installer failed', stdout: '', stderr: 'pip failed',
+			},
+		};
+		const service = new PlatformioDiagnosticService({
+			existsSync: existsSyncStub, execFile: execFileStub, env: { PATH: '/custom/penv/bin' },
+			platform: 'darwin', homeDir: '/Users/tester', now: () => now, localeService,
+			managedRuntime: {
+				getStatus: sinon.stub().resolves({ status: 'missing' }),
+				getStorageSummary: () => '<managed-storage:123456789abc>',
+				getStorageUsageBytes: sinon.stub().resolves(0),
+				getProvisioningState: () => provisioning,
+			},
+		});
+
+		const session = await service.collectDiagnostics('/workspace/demo');
+
+		assert.strictEqual(session.overallStatus, 'degraded');
+		assert.strictEqual(session.coreDiagnostics?.environments.provider.status, 'healthy');
+		assert.strictEqual(session.coreDiagnostics?.environments.managed.failureClass, 'managed-provisioning');
+		assert.strictEqual(session.coreDiagnostics?.environments.managed.provisioning, provisioning);
+		assert.match(session.coreDiagnostics?.environments.managed.reason ?? '', /installing-platformio.*code 1/);
+
+		provisioning = {
+			status: 'running', attempt: 4, trigger: 'editor-open', stage: 'extracting-python', percent: 25,
+			startedAt: now.toISOString(), updatedAt: now.toISOString(),
+		};
+		const activeSession = await service.collectDiagnostics('/workspace/demo');
+		assert.strictEqual(activeSession.overallStatus, 'degraded');
+		assert.strictEqual(activeSession.coreDiagnostics?.environments.managed.provisioning, provisioning);
+		assert.match(activeSession.coreDiagnostics?.environments.managed.reason ?? '', /extracting-python.*25%/);
 	});
 
 	test('reports missing and corrupt managed runtimes without starting an installer', async () => {

--- a/src/test/services/platformioIssueDraftService.test.ts
+++ b/src/test/services/platformioIssueDraftService.test.ts
@@ -95,6 +95,28 @@ suite('PlatformioIssueDraftService Tests', () => {
 		assert.ok(draft.noDraftReason?.includes('operational'));
 		assert.strictEqual(draft.body, 'No issue draft recommended: diagnostics are operational.');
 	});
+
+	test('recommends a draft when provider tools are operational but managed provisioning failed', () => {
+		const service = new PlatformioIssueDraftService({ homeDir: '/Users/alice' });
+		const coreDiagnostics = createCoreDiagnostics();
+		coreDiagnostics.environments.managed.provisioning = {
+			status: 'failed', attempt: 1, trigger: 'activation', stage: 'installing-platformio', percent: 40,
+			startedAt: '2026-01-02T03:00:00.000Z', failedAt: '2026-01-02T03:01:00.000Z',
+			failure: {
+				failureDomain: 'managed-provisioning', stage: 'installing-platformio', code: '1', started: true,
+				message: 'installer failed', stdout: '', stderr: '/Users/alice/private-runtime',
+			},
+		};
+		const session = createDiagnosticSession({ overallStatus: 'operational', coreDiagnostics });
+
+		const draft = service.buildDraft({ session, source: 'human-confirmed' });
+
+		assert.strictEqual(draft.candidacy, 'recommended');
+		assert.ok(draft.title.includes('managed-provisioning'));
+		assert.ok(draft.body.includes('Managed provisioning: failed'));
+		assert.ok(draft.body.includes('managed-provisioning: attempt 1 failed at installing-platformio'));
+		assert.ok(!draft.body.includes('/Users/alice'));
+	});
 });
 
 function createCoreDiagnostics(): NonNullable<ReturnType<typeof createDiagnosticSession>['coreDiagnostics']> {

--- a/src/test/services/platformioPrivacyRedactor.test.ts
+++ b/src/test/services/platformioPrivacyRedactor.test.ts
@@ -36,6 +36,17 @@ suite('PlatformioPrivacyRedactor Tests', () => {
 		assert.ok(output.includes('<home>\\.platformio\\penv\\Scripts\\python.exe'));
 	});
 
+	test('redacts raw and URI-encoded managed runtime paths', () => {
+		const managedRuntimePath = 'C:\\Users\\王小明\\AppData\\Roaming\\Code\\User\\globalStorage\\Singular-Ray.singular-blockly\\runtime-v1';
+		const redactor = new PlatformioPrivacyRedactor({ managedRuntimePath });
+		const encodedPath = encodeURI(managedRuntimePath.replace(/\\/g, '/'));
+
+		const output = redactor.redact(`${managedRuntimePath} ${encodedPath}`);
+
+		assert.ok(!output.includes('王小明'));
+		assert.strictEqual(output, '<managed-runtime> <managed-runtime>');
+	});
+
 	test('redacts proxy credentials without removing the proxy host', () => {
 		const redactor = new PlatformioPrivacyRedactor();
 

--- a/src/test/webview/platformioDiagnosticPanel.test.ts
+++ b/src/test/webview/platformioDiagnosticPanel.test.ts
@@ -697,5 +697,9 @@ suite('PlatformioDiagnosticPanel Tests', () => {
 		assert.ok(script.includes('elements.feedbackBanner.textContent = message;'), 'Feedback messages must use textContent');
 		assert.ok(script.includes('elements.exportNotice.textContent = notice;'), 'Export notices must use textContent');
 		assert.ok(script.includes("vscode.postMessage({ command: 'platformioDiagnostic:revealManagedRuntime' });"), 'Managed runtime reveal must use a fixed command without a webview-provided path');
+		assert.ok(script.includes('${renderProvisioningDetails(environment.provisioning)}'), 'Managed runtime cards must render provisioning evidence');
+		assert.ok(script.includes("return renderDetailBlock('managed-provisioning', fields.join('; '));"), 'Provisioning evidence must use the existing escaped detail renderer');
+		assert.ok(script.includes('`stdout=${provisioning.failure.stdout}`'), 'Managed runtime cards must expose bounded installer stdout');
+		assert.ok(script.includes('`stderr=${provisioning.failure.stderr}`'), 'Managed runtime cards must expose bounded installer stderr');
 	});
 });

--- a/src/types/coreEnvironment.ts
+++ b/src/types/coreEnvironment.ts
@@ -15,6 +15,7 @@ export type CoreFailureClass =
 	| 'python-import'
 	| 'permission'
 	| 'local-store-corruption'
+	| 'managed-provisioning'
 	| 'compile'
 	| 'project-config'
 	| 'dns'

--- a/src/types/managedRuntime.ts
+++ b/src/types/managedRuntime.ts
@@ -8,6 +8,49 @@ export type ManagedRuntimePlatform = 'win32' | 'darwin' | 'linux';
 export type ManagedRuntimeArch = 'x64' | 'arm64';
 export type RuntimeSupportStatus = 'stable' | 'release-candidate';
 
+export type ManagedRuntimeInstallStage =
+	| 'waiting-lock'
+	| 'downloading-python'
+	| 'extracting-python'
+	| 'installing-platformio'
+	| 'installing-mpremote'
+	| 'verifying'
+	| 'committing';
+
+export type ManagedRuntimeProvisioningTrigger = 'activation' | 'editor-open' | 'workload' | 'repair';
+
+export interface ManagedRuntimeProvisioningFailure {
+	failureDomain: 'managed-provisioning';
+	stage: ManagedRuntimeInstallStage;
+	code: string;
+	started: boolean;
+	message: string;
+	stdout: string;
+	stderr: string;
+}
+
+export type ManagedRuntimeProvisioningState =
+	| { status: 'idle'; attempt: number }
+	| {
+		status: 'running';
+		attempt: number;
+		trigger: ManagedRuntimeProvisioningTrigger;
+		stage: ManagedRuntimeInstallStage;
+		percent: number;
+		startedAt: string;
+		updatedAt: string;
+	}
+	| {
+		status: 'failed';
+		attempt: number;
+		trigger: ManagedRuntimeProvisioningTrigger;
+		stage: ManagedRuntimeInstallStage;
+		percent: number;
+		startedAt: string;
+		failedAt: string;
+		failure: ManagedRuntimeProvisioningFailure;
+	};
+
 export interface RuntimeDownload {
 	url: string;
 	sha256: string;

--- a/src/types/platformioDiagnostic.ts
+++ b/src/types/platformioDiagnostic.ts
@@ -134,6 +134,7 @@ export interface CoreDiagnosticEnvironment {
 	packageStatus: import('./coreEnvironment').PackageHealthStatus;
 	failureClass: import('./coreEnvironment').CoreFailureClass | null;
 	reason: string;
+	provisioning?: import('./managedRuntime').ManagedRuntimeProvisioningState;
 }
 
 export interface CoreDiagnosticSummary {


### PR DESCRIPTION
## 變更摘要 Summary

修正 Windows 上 Singular Managed Core 在 `installing-platformio` 階段失敗時診斷證據遺失、受管環境狀態不可見及無法安全 fallback 的問題，並準備 v0.87.1 修補版本。

Closes #130

## 相關 Spec Related Spec

- Spec: `specs/067-managed-platformio-environment/spec.md`
- Tasks: `specs/067-managed-platformio-environment/tasks.md`

## 變更類型 Type of Change

- [x] 🐛 Bug 修復
- [x] 📝 文件與 SDD 更新
- [ ] ✨ 新功能
- [ ] 💥 破壞性變更

## 變更內容 Changes

- 保留並隱私遮蔽受管 Runtime 安裝的 stage、stdout、stderr、code 與 started 證據。
- 將 managed-provisioning 與工作負載失敗分離，允許通過探測及準備閘門的 Provider fallback。
- 縮短 immutable Runtime 版本目錄，降低 Windows 傳統長路徑風險。
- 統一啟用、編輯器開啟與修復期間的 provisioning 狀態及 in-flight transaction。
- 在診斷面板、AI repair packet 與 issue draft 呈現遮蔽後的 provisioning 狀態。
- 擴充真實安裝 E2E，涵蓋中文、空格、特殊字元及 VS Code globalStorage 形式路徑。

## 測試計劃 Test Plan

- [x] `npm run ci:static`
- [x] `npm run test:unit:ci`：1225 passing，1 個既有 Copilot service pending
- [x] `npm run test:integration`：9 passing，3 個既有 Copilot service pending
- [x] `npm run test:managed-runtime:paths`：5/5 PASS
- [x] macOS ARM64 真實 Managed Runtime 安裝與離線重啟 PASS
- [x] `npm run package`
- [x] `npm run release:prepare`
- [x] `npm audit --omit=dev --audit-level=high`：0 vulnerabilities
- [ ] GitHub CI、CodeQL 與完整 x64/ARM64 Runtime matrix
- [ ] 乾淨 Windows F5 診斷驗證
- [ ] Arduino 與 CyberBrick 實機 smoke test

## 發布資訊 Release Metadata

- Version: `v0.87.1`
- `package.json`、`package-lock.json` 與雙語 `CHANGELOG.md` 已包含於本 PR
- 本地 Code Review：CLEAR，4 項 finding 已採納並修正

## 殘餘風險 Residual Risk

v0.87.0 未保存失敗安裝程序的 stderr，因此無法事後唯一確認 Windows 原始根因。本修補版補足可觀測性並降低長路徑風險；合併前仍須通過 Windows Runtime matrix、乾淨 Windows F5 與實機閘門。