### PR TITLE
chore(deps-dev): 升級 TypeScript 至 6.0.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - VS Code extension for visual Arduino/MicroPython programming with Google Blockly.
 - Generates Arduino C++ through PlatformIO and MicroPython through `mpremote` for CyberBrick.
 - Supports 15 locales; validate localization changes before shipping.
-- Runtime/tooling baseline: TypeScript 5.9.3, Blockly 13.2.1, `@blockly/theme-modern` 13.2.0, VS Code `^1.109.0`, Node.js 22.16.0+ for contributors.
+- Runtime/tooling baseline: TypeScript 6.0.3, Blockly 13.2.1, `@blockly/theme-modern` 13.2.0, VS Code `^1.109.0`, Node.js 22.16.0+ for contributors.
 - PlatformIO IDE (`platformio.platformio-ide`) is an extension dependency.
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Example project: [CyberBrick SoccerBot](https://github.com/Shen-Ming-Hong/Blockl
 
 ## Development
 
-Contributor baseline: Node.js 22.16.0+, TypeScript 5.9.3, Blockly 13.2.1, `@blockly/theme-modern` 13.2.0, and VS Code 1.109.0+.
+Contributor baseline: Node.js 22.16.0+, TypeScript 6.0.3, Blockly 13.2.1, `@blockly/theme-modern` 13.2.0, and VS Code 1.109.0+.
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"ovsx": "1.1.1",
 				"sinon": "^22.1.0",
 				"ts-loader": "^9.6.2",
-				"typescript": "^5.9.3",
+				"typescript": "^6.0.3",
 				"webpack": "^5.109.2",
 				"webpack-cli": "^7.2.2"
 			},
@@ -8986,10 +8986,11 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
 		"ovsx": "1.1.1",
 		"sinon": "^22.1.0",
 		"ts-loader": "^9.6.2",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"webpack": "^5.109.2",
 		"webpack-cli": "^7.2.2"
 	},


### PR DESCRIPTION
## 變更摘要 Summary

以 human-owned PR 將 TypeScript 從 5.9.3 升級至 6.0.3，取代 Dependabot #129，並同步現行貢獻者工具鏈文件。這是例行 Version Update，不改變產品 runtime 行為、擴充套件版本或發布內容。

## 相關 Spec / Issue

- Supersedes #129
- SDD gate: Lightweight plan
- Spec: 不適用；沒有產品設計或架構契約變更

## 變更類型 Type of Change

- [ ] 🐛 Bug 修復
- [ ] ✨ 新功能
- [ ] 💥 破壞性產品變更
- [x] 📝 文件更新
- [ ] 🔧 重構
- [ ] 🌍 國際化
- [x] 📦 開發依賴更新

## 變更內容 Changes

- 將 `typescript` 從 `^5.9.3` 升級至 `^6.0.3`。
- 更新並驗證 `package-lock.json` 的 registry URL、integrity 與 Apache-2.0 license metadata。
- 同步 `AGENTS.md` 與 `README.md` 的 TypeScript 工具鏈基準。
- 保留 Node.js 22.16.0、VS Code 1.109.0、產品版本 0.87.4 與歷史 specs 不變。

## 測試計劃 Test Plan

- [x] `npm ci`
- [x] `npm audit`：0 vulnerabilities
- [x] `npm ls typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin ts-loader`
- [x] `npm run ci:static`
- [x] `npm run test:unit:ci`：1,276 passing、1 pending
- [x] `npm run package`
- [x] `npm run release:prepare`
- [x] `tsc -p . --noEmit --stableTypeOrdering`
- [x] 本地 code review：CLEAR，0 個 P0–P3 findings

## 安全與發布 Security and Release

- `npm audit` 無漏洞，lockfile integrity 與 npm registry 一致。
- 無 TS/JS 程式碼、WebView、命令執行、檔案 I/O 或敏感資料變更。
- 本 PR 不 bump extension version、不修改 CHANGELOG、不建立 tag，也不觸發正式發布。

## 螢幕截圖 Screenshots

不適用；沒有 UI 變更。