### PR TITLE
fix(security): 修復 CodeQL 時間戳警告

### DIFF
--- a/.github/skills/security-vulnerability-fix/SKILL.md
+++ b/.github/skills/security-vulnerability-fix/SKILL.md
@@ -1,65 +1,82 @@
 ---
 name: security-vulnerability-fix
-description: 修復 npm 依賴安全漏洞的完整工作流程。當使用者提到安全警告、Dependabot Security Alerts、CVE、GHSA 或 npm audit 漏洞時使用；不適用於沒有安全公告的例行 Dependabot Version Update PR。包含漏洞分析、依賴升級、驗證、PR、annotated tag 與 GitHub Actions CD。Fix npm security vulnerabilities from Dependabot alerts, CVEs, GHSAs, or npm audit findings, then release through the protected-branch and tag-driven CI/CD workflow; do not use for routine version-update PRs without a security advisory.
+description: 修復 npm 依賴與 GitHub Code Scanning 程式碼安全漏洞的完整工作流程。當使用者提到安全警告、Dependabot Security Alerts、CodeQL、Code Scanning、CVE、GHSA 或 npm audit 漏洞時使用；不適用於沒有安全 finding 的例行版本更新。包含漏洞分析、依賴或原始碼修正、驗證、PR、annotated tag 與 GitHub Actions CD。Fix npm dependency and GitHub Code Scanning vulnerabilities from Dependabot, CodeQL, CVEs, GHSAs, or npm audit findings, then release through the protected-branch and tag-driven CI/CD workflow; do not use for routine updates without a security finding.
 metadata:
     author: singular-blockly
-    version: '2.0.0'
+    version: '2.1.0'
     category: security
 ---
 
 # 安全漏洞修復技能 Security Vulnerability Fix Skill
 
-修復 npm 依賴安全漏洞的標準化工作流程。
-A standardized workflow for fixing npm dependency security vulnerabilities.
+修復 npm 依賴與 GitHub Code Scanning 程式碼安全漏洞的標準化工作流程。
+A standardized workflow for fixing npm dependency and GitHub Code Scanning vulnerabilities.
 
 ## 適用情境 When to Use
 
 - 收到 Dependabot security alerts
+- 收到 GitHub Code Scanning／CodeQL alerts
 - 執行 `npm audit` 發現漏洞
 - 需要升級有 CVE 的套件
+- 需要修復 CodeQL 指出的安全程式碼 finding
 - 發布安全修補版本 (PATCH release)
 
-不要把單純「有較新版本」的 Dependabot Version Update PR 視為安全漏洞。沒有 open Security Alert、CVE／GHSA 或 `npm audit` finding 時，改用一般依賴升級流程，不要自動 bump 專案版本或發布安全修補版。
+不要把單純「有較新版本」的 Dependabot Version Update PR 視為安全漏洞。Dependabot 與 Code Scanning 都沒有 open alert，且 `npm audit` 為 0 時，改用一般依賴升級流程，不要自動 bump 專案版本或發布安全修補版。
 
 ## 工作流程 Workflow
 
 ### Phase 1: 漏洞分析 Vulnerability Analysis
 
-1. **查詢所有安全警告**
+1. **查詢所有 Dependabot 安全警告**
 
     ```bash
-    gh api repos/{owner}/{repo}/dependabot/alerts --jq '.[] | {number: .number, state: .state, severity: .security_advisory.severity, package: .security_vulnerability.package.name, summary: .security_advisory.summary}'
+    gh api --paginate 'repos/{owner}/{repo}/dependabot/alerts?state=open&per_page=100' --jq '.[] | {number: .number, state: .state, severity: .security_advisory.severity, package: .security_vulnerability.package.name, summary: .security_advisory.summary}'
     ```
 
-2. **深入分析特定警告** (取得 CVE、修復版本、CVSS 分數)
+2. **查詢所有 GitHub Code Scanning 警告**
+
+    ```bash
+    gh api --paginate 'repos/{owner}/{repo}/code-scanning/alerts?state=open&per_page=100' --jq '.[] | {number: .number, state: .state, rule: .rule.id, severity: .rule.security_severity_level, tool: .tool.name, path: .most_recent_instance.location.path, line: .most_recent_instance.location.start_line, summary: .rule.description}'
+    ```
+
+3. **深入分析特定警告**
+
+    Dependabot alert：取得 CVE、GHSA、修復版本與 CVSS 分數。
 
     ```bash
     gh api repos/{owner}/{repo}/dependabot/alerts/{alert_number}
     ```
 
-3. **確認目前安裝版本**
+    Code Scanning alert：取得規則、CWE、精確位置、訊息、commit 與掃描工具版本，並閱讀命中位置的原始碼與相關測試；不得只看摘要就判定誤報或 dismiss。
+
+    ```bash
+    gh api repos/{owner}/{repo}/code-scanning/alerts/{alert_number}
+    ```
+
+4. **確認目前安裝版本**（依賴 finding）
 
     ```bash
     npm ls {package_name}
     ```
 
-4. **本地漏洞掃描**（與 Dependabot 交叉比對）
+5. **本地漏洞掃描**（與 Dependabot 交叉比對）
 
     ```bash
     npm audit
     ```
 
-    如果 Security Alerts 沒有 open 項目且 `npm audit` 為 0，停止安全修補流程並回報這是一般版本更新。
+    只有在 Dependabot 與 Code Scanning 都沒有 open alert，且 `npm audit` 為 0 時，才能停止安全修補流程並回報沒有安全 finding。`npm audit` 為 0 不代表 Code Scanning 為 0。
 
-5. **評估風險**
+6. **評估風險**
     - Critical/High: 立即修復
     - Medium: 排程修復
     - Low: 評估是否需要
 
-6. **判斷依賴類型**
+7. **判斷 finding 類型與修復路徑**
     - 直接依賴 (direct) → 直接升級 package.json 中的版本
     - 間接依賴 (transitive) → 先升級最近的直接／上游依賴；只有沒有安全相容版本時才使用精確、最小範圍的 `overrides`
     - devDependency → 仍需分析實際 build／CI 暴露面；不要只因是開發依賴就忽略漏洞
+    - Code Scanning → 修正命中位置的根因並補足相稱的回歸測試；只有能以原始碼、資料流與實際執行條件證明是 false positive 時，才提出 dismissal 方案
 
 ### Phase 2: 版本規劃 Version Planning
 
@@ -68,22 +85,23 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
     - 含新功能 → MINOR (x.Y.0)
     - 有 breaking changes → MAJOR (X.0.0)
 
-2. **檢查修復版本是否可用**
+2. **檢查修復版本是否可用**（依賴 finding）
     ```bash
     npm view {package_name} versions --json | tail -5
     ```
 
 3. **提出修復方案並取得核准**
-    - 列出 Alert／CVE／GHSA、嚴重度、受影響依賴路徑與修復版本。
-    - 說明直接升級或 `overrides` 的選擇及相容性風險。
+    - 列出 Dependabot Alert／CVE／GHSA 或 Code Scanning Alert／rule／CWE、嚴重度、受影響依賴路徑或原始碼位置。
+    - 說明直接升級、`overrides` 或原始碼修正的選擇及相容性風險。
     - 提出 SemVer、雙語 CHANGELOG 草稿、測試範圍與預定 `vX.Y.Z`。
     - 未取得修正核准前，不修改 dependency、版本或 CHANGELOG。
 
 ### Phase 3: 實施修復 Implementation
 
-1. **在功能分支更新依賴與版本**
+1. **在功能分支修復 finding 並更新版本**
     - 直接依賴：修改 `dependencies` / `devDependencies` 中的版本。
     - 間接依賴：只在無法由上游安全版本解決時使用精確、最小範圍的 `overrides`。
+    - Code Scanning：以最小變更修正根因並新增或調整可驗證行為的測試，不以註解、忽略規則或無根據 dismissal 掩蓋 finding。
     - 使用 `npm version {VERSION} --no-git-tag-version` 同步更新 `package.json` 與 `package-lock.json`；此時禁止建立 tag。
 
     ```jsonc
@@ -108,6 +126,17 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
           Closes Dependabot Alert #{number}
     ```
 
+    Code Scanning finding 改用對應條目：
+
+    ```markdown
+    - **修復 CodeQL {rule_id} ({CWE})** (Fix CodeQL {rule_id})
+        - 修正 `{path}:{line}` 的 {vulnerability type}
+          Fixed {vulnerability type} in `{path}:{line}`
+        - 嚴重程度 Severity: {severity}
+        - 關閉 Code Scanning Alert #{number}
+          Closes Code Scanning Alert #{number}
+    ```
+
 3. **安裝並驗證**
 
     ```bash
@@ -121,7 +150,7 @@ A standardized workflow for fixing npm dependency security vulnerabilities.
     npm run release:prepare
     ```
 
-    目標 Alert／CVE 必須消失，Critical／High finding 必須為 0。若仍有與本次無關且無可用修復的 Medium／Low finding，列出 dependency path、影響與緩解措施，取得使用者明確的殘餘風險核准；不得把有 finding 的結果描述成 `0 vulnerabilities`。
+    依賴 Alert／CVE 必須從 lockfile 與 `npm audit` 消失；Code Scanning finding 必須先以原始碼檢查與測試驗證，並在 PR 的新 CodeQL 掃描中消失。Critical／High finding 必須為 0。若仍有與本次無關且無可用修復的 Medium／Low finding，列出 dependency path 或 code location、影響與緩解措施，取得使用者明確的殘餘風險核准；不得把仍有任何來源 finding 的結果描述成 `0 vulnerabilities`。
 
 4. **驗證測試失敗為既有問題**（如有測試失敗）
 
@@ -181,7 +210,7 @@ _Last updated: YYYY-MM-DD_
 
 2. **取得發布核准後建立 PR**
     - 不得直接 push `master`，也不得在 PR 合併前建立正式 tag。
-    - PR 描述列出 Alert／CVE、修復版本、雙語 CHANGELOG 摘要、`npm audit` 與測試結果。
+    - PR 描述列出 Dependabot／Code Scanning Alert、CVE／GHSA／CodeQL rule、修復版本、雙語 CHANGELOG 摘要、`npm audit`、測試與 CodeQL 結果。
     - 等待 `CI Gate`、CodeQL、review 對話與受保護分支條件全部通過。
     - 只使用 squash merge，並刪除遠端功能分支。
 
@@ -234,6 +263,7 @@ _Last updated: YYYY-MM-DD_
 
     ```bash
     gh api repos/{owner}/{repo}/dependabot/alerts/{number} --jq '{state: .state, fixed_at: .fixed_at}'
+    gh api repos/{owner}/{repo}/code-scanning/alerts/{number} --jq '{state: .state, fixed_at: .fixed_at, rule: .rule.id}'
     ```
 
 2. **本地與發布端最終確認**
@@ -254,8 +284,9 @@ _Last updated: YYYY-MM-DD_
       從 Marketplace JSON 讀取最新版的 `Microsoft.VisualStudio.Services.VsixSha256`。三個值都必須等於 Actions 唯一 artifact 的 SHA-256。
 
 3. **如果警告未自動轉為 `fixed`**
-    - 先確認修復後的 `package-lock.json` 已在 default branch，且實際 dependency path 不再落入 vulnerable range。
-    - 等待 Dependabot 重新掃描並再次查詢；掃描延遲不代表修復失敗。
+    - Dependabot：先確認修復後的 `package-lock.json` 已在 default branch，且實際 dependency path 不再落入 vulnerable range。
+    - Code Scanning：先確認修正 commit 已在 default branch、該 commit 的 CodeQL workflow 成功，且新掃描涵蓋相同語言與 alert 位置。
+    - 等待 Dependabot 或 Code Scanning 重新掃描並再次查詢；掃描延遲不代表修復失敗。
     - 不得把真實漏洞手動 dismiss 成已處理。只有確認為 false positive、不可觸及程式碼或接受風險，並取得使用者明確核准後，才使用與事實相符的 dismissal reason 與完整註解。
 
 ## 雙語內容範本 Bilingual Content Templates
@@ -265,12 +296,12 @@ _Last updated: YYYY-MM-DD_
 
 ## 檢查清單 Checklist
 
-- [ ] 查詢並分析安全警告
+- [ ] 查詢並分析 Dependabot 與 Code Scanning 安全警告
 - [ ] 確認修復版本可用
-- [ ] 更新 package.json (依賴 + 版本號)
+- [ ] 更新 package.json 與 lockfile（版本；依賴 finding 才變更 dependency）
 - [ ] 更新 CHANGELOG.md (雙語格式)
 - [ ] 更新 SECURITY.md (移除已修復漏洞、更新支援版本)
-- [ ] 目標漏洞已排除、Critical／High 為 0；任何剩餘 Medium／Low finding 已明確核准
+- [ ] 目標依賴與 Code Scanning 漏洞已排除、Critical／High 為 0；任何剩餘 Medium／Low finding 已明確核准
 - [ ] `ci:static`、unit tests、release tests 與 `release:prepare` 通過
 - [ ] 本地 review、修正核准、re-review 與發布前核准完成
 - [ ] 版本、lockfile、雙語 CHANGELOG 與安全修正已進入同一 PR
@@ -279,12 +310,12 @@ _Last updated: YYYY-MM-DD_
 - [ ] Actions 使用唯一 VSIX 完成 GitHub Release、Marketplace 與 Open VSX
 - [ ] 三端版本與 SHA-256 一致；本機未重建正式產物
 - [ ] 失敗時只復原失敗發布端，未刪除或重建 tag
-- [ ] 驗證 Dependabot 警告已關閉 (`state: fixed`)
-- [ ] 最終 `npm audit` 結果已如實回報，未隱藏或誤稱剩餘 finding
+- [ ] 驗證 Dependabot 與 Code Scanning 警告已關閉 (`state: fixed`)
+- [ ] 最終 Dependabot、Code Scanning 與 `npm audit` 結果已如實回報，未隱藏或誤稱剩餘 finding
 
 ## 相關工具 Related Tools
 
-- `gh api` - GitHub CLI API 操作
+- `gh api` - 查詢 Dependabot 與 Code Scanning alerts
 - `npm audit` - 本地漏洞掃描
 - `npm ls` - 查看依賴樹
 - `npm run release:prepare` - 驗證 tag 前版本與 CHANGELOG 契約

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.87.5] - 2026-08-19
+
+### 🔒 安全性 Security
+
+- 移除 Project Skill 備份與無效工作區隔離檔名時間戳中的無效字串替換，在維持既有 UTC 格式不變的同時修復 CodeQL `js/identity-replacement`（CWE-116）Code Scanning Alerts #12 與 #13
+  Removed ineffective string replacements from Project Skill backup and invalid-workspace quarantine filename timestamps, preserving the existing UTC format while fixing CodeQL `js/identity-replacement` (CWE-116) Code Scanning Alerts #12 and #13
+- 強化 `security-vulnerability-fix` Skill，要求每次漏洞分析同時查詢 Dependabot、GitHub Code Scanning 與 `npm audit`，避免將 `npm audit` 為 0 誤報為沒有任何安全 finding
+  Strengthened the `security-vulnerability-fix` Skill to query Dependabot, GitHub Code Scanning, and `npm audit` on every vulnerability analysis, preventing a zero-result npm audit from being misreported as no security findings
+
+### 🧪 測試 Tests
+
+- 補強 Project Skill 備份與無效工作區隔離檔名的精確 UTC 時間戳回歸驗證
+  Strengthened exact UTC timestamp regression coverage for Project Skill backup and invalid-workspace quarantine filenames
+
 ## [0.87.4] - 2026-08-19
 
 ### 🐛 修復 Bug Fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.83.x  | :white_check_mark: |
-| < 0.83  | :x:                |
+| 0.87.x  | :white_check_mark: |
+| < 0.87  | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -15,7 +15,10 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 | Package  | Severity | Advisory | Reason                                                    |
 | -------- | -------- | -------- | --------------------------------------------------------- |
-| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.83.1 |
+| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.87.5 |
+
+> **0.87.5 更新 Update**: 移除 Project Skill 備份與無效工作區隔離檔名時間戳中的無效字串替換，在維持既有 UTC 格式不變的同時修復 GitHub Code Scanning Alerts #12 與 #13（CodeQL `js/identity-replacement`、CWE-116）；本地 `npm audit` 顯示 0 vulnerabilities，GitHub Dependabot open alerts 為 0。
+> Removed ineffective string replacements from Project Skill backup and invalid-workspace quarantine filename timestamps, preserving the existing UTC format while fixing GitHub Code Scanning Alerts #12 and #13 (CodeQL `js/identity-replacement`, CWE-116); local `npm audit` reports 0 vulnerabilities and GitHub Dependabot has 0 open alerts.
 
 > **0.83.1 更新 Update**: `@modelcontextprotocol/sdk` 升級至 `1.30.0`，並透過 overrides 將 `hono`、`@hono/node-server`、`body-parser`、`fast-uri`、`ip-address`、`js-yaml` 與三條 `brace-expansion` 相容分支升級至安全版本，修復 Dependabot Alerts #83–#91、#95–#96、#98、#102–#104。本地 `npm audit` 顯示 0 vulnerabilities。
 > `@modelcontextprotocol/sdk` was upgraded to `1.30.0`, with overrides updating `hono`, `@hono/node-server`, `body-parser`, `fast-uri`, `ip-address`, `js-yaml`, and three compatible `brace-expansion` branches to safe versions, fixing Dependabot Alerts #83–#91, #95–#96, #98, and #102–#104. Local `npm audit` reports 0 vulnerabilities.
@@ -61,4 +64,4 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 ---
 
-_Last updated: 2026-08-04_
+_Last updated: 2026-08-19_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "singular-blockly",
-	"version": "0.87.4",
+	"version": "0.87.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "singular-blockly",
-			"version": "0.87.4",
+			"version": "0.87.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "singular-blockly",
 	"displayName": "Singular Blockly",
 	"description": "VS Code extension for visual Arduino & MicroPython programming with Blockly. Multi-board support, project-local Agent Skills, AI camera integration, PlatformIO integration, and 15 languages.",
-	"version": "0.87.4",
+	"version": "0.87.5",
 	"license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.109.0",

--- a/src/services/projectSkillService.ts
+++ b/src/services/projectSkillService.ts
@@ -335,6 +335,6 @@ export class ProjectSkillService {
 	}
 
 	private static timestamp(date: Date): string {
-		return date.toISOString().replace(/[-:.]/g, '').replace('Z', 'Z');
+		return date.toISOString().replace(/[-:.]/g, '');
 	}
 }

--- a/src/services/workspaceCandidateService.ts
+++ b/src/services/workspaceCandidateService.ts
@@ -686,7 +686,7 @@ export class WorkspaceCandidateService implements vscode.Disposable {
 	}
 
 	private static timestamp(date: Date): string {
-		return date.toISOString().replace(/[-:.]/g, '').replace('Z', 'Z');
+		return date.toISOString().replace(/[-:.]/g, '');
 	}
 
 	private static sha256(bytes: Uint8Array): string {

--- a/src/test/services/workspaceCandidateService.test.ts
+++ b/src/test/services/workspaceCandidateService.test.ts
@@ -480,6 +480,7 @@ suite('WorkspaceCandidateService Tests', () => {
 		const names = fs.readdirSync(path.join(workspace, 'blockly'));
 		assert.ok(names.includes('main.invalid.json'));
 		assert.ok(names.includes('main.invalid.keep.json'));
+		assert.ok(names.includes('main.invalid.20260812T081530123Z-6.json'));
 		assert.strictEqual(names.filter(name => /^main\.invalid\.\d{8}T\d{9}Z-\d+\.json$/.test(name)).length, 5);
 	});
 


### PR DESCRIPTION
## 變更摘要 Summary

修復 CodeQL `js/identity-replacement`（CWE-116）Code Scanning Alerts #12 與 #13，移除兩個時間戳 helper 的無效 `Z` 自我替換，同時保留既有 UTC 檔名格式。

Fixes CodeQL `js/identity-replacement` (CWE-116) Code Scanning Alerts #12 and #13 by removing ineffective self-replacements of `Z` from two timestamp helpers while preserving the existing UTC filename format.

## 安全警告 Security Alerts

- Code Scanning Alert #12: `src/services/projectSkillService.ts`
- Code Scanning Alert #13: `src/services/workspaceCandidateService.ts`
- Severity: Medium
- Dependabot open alerts: 0
- `npm audit`: 0 vulnerabilities

## 變更內容 Changes

- 移除 Project Skill 備份與工作區隔離歷史時間戳中的 identity replacement
- 補強無效工作區隔離檔名的精確 UTC 時間戳回歸測試
- 將 `security-vulnerability-fix` Skill 更新至 v2.1.0，強制分頁查詢 Dependabot、GitHub Code Scanning 與 `npm audit`
- 同步版本 `0.87.5`、雙語 CHANGELOG 與 SECURITY.md

## 測試計劃 Test Plan

- [x] 精準回歸測試：73 passing
- [x] `npm run ci:static`
- [x] `npm run test:unit:ci`：1,276 passing、1 pending
- [x] `npm run test:release`：23 passing
- [x] `npm run release:prepare`
- [x] Skill `quick_validate.py`
- [x] `npm audit`：0 vulnerabilities

## 發布資訊 Release Metadata

- Version: `v0.87.5`
- `package.json`、`package-lock.json`、雙語 `CHANGELOG.md` 與 `SECURITY.md` 已包含在本 PR
- 正式發布只會由 annotated tag 觸發 GitHub Actions，且不在本機建立正式 VSIX

## 相關 Spec Related Spec

- `specs/066-agent-skills-mcp-retirement/`
