### PR TITLE
ci(release): 改用 Entra 聯合身分發布 Marketplace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,7 @@ jobs:
     environment: release
     permissions:
       contents: read
+      id-token: write
     env:
       ARTIFACT_NAME: ${{ needs.quality.outputs['artifact-name'] }}
       VSIX_NAME: ${{ needs.quality.outputs['vsix-name'] }}
@@ -108,6 +109,16 @@ jobs:
       - name: Install pinned publishing tools
         run: npm ci
 
+      - name: Sign in to Azure with the Marketplace publishing identity
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Verify Marketplace publishing identity
+        run: npm exec -- vsce verify-pat Singular-Ray --azure-credential
+
       - name: Download verified release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -116,15 +127,11 @@ jobs:
 
       - name: Publish the shared VSIX
         if: github.run_attempt == 1
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npm exec -- vsce publish --packagePath "release-artifacts/$VSIX_NAME"
+        run: npm exec -- vsce publish --azure-credential --packagePath "release-artifacts/$VSIX_NAME"
 
       - name: Retry an ambiguously completed Marketplace publish
         if: github.run_attempt > 1
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npm exec -- vsce publish --packagePath "release-artifacts/$VSIX_NAME" --skip-duplicate
+        run: npm exec -- vsce publish --azure-credential --packagePath "release-artifacts/$VSIX_NAME" --skip-duplicate
 
   publish-open-vsx:
     name: Publish Open VSX

--- a/.github/workflows/verify-marketplace-identity.yml
+++ b/.github/workflows/verify-marketplace-identity.yml
@@ -1,0 +1,72 @@
+name: Verify Marketplace Entra Identity
+
+on:
+  workflow_dispatch:
+    inputs:
+      verify_membership:
+        description: Verify Contributor membership after the Marketplace User ID is added
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-profile:
+    name: Resolve Marketplace User ID
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Sign in to Azure with the Marketplace publishing identity
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Resolve the Marketplace profile
+        shell: bash
+        run: |
+          set -euo pipefail
+          profile_json="$(az rest \
+            --method get \
+            --url 'https://app.vssps.visualstudio.com/_apis/profile/profiles/me' \
+            --resource '499b84ac-1321-427f-aa17-267ca6975798')"
+          profile_id="$(jq -r '.id // empty' <<< "$profile_json")"
+          if [[ ! "$profile_id" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+            echo 'Marketplace did not return a valid profile ID.' >&2
+            exit 1
+          fi
+
+          echo "::notice title=Marketplace identity User ID::$profile_id"
+          {
+            echo '## Marketplace Entra identity'
+            echo
+            echo "User ID: \`$profile_id\`"
+            echo
+            echo 'This diagnostic workflow does not package or publish an extension.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout repository
+        if: inputs.verify_membership
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js 22.16.0
+        if: inputs.verify_membership
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.16.0
+          cache: npm
+
+      - name: Install pinned publishing tools
+        if: inputs.verify_membership
+        run: npm ci
+
+      - name: Verify Marketplace Contributor membership
+        if: inputs.verify_membership
+        run: npm exec -- vsce verify-pat Singular-Ray --azure-credential

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -90,10 +90,19 @@ gh workflow run recover-github-release.yml --ref master \
 ### Release environment
 
 - 建立名為 `release` 的 environment。
-- 既有 repository secrets `VSCE_PAT`、`OVSX_PAT` 可直接沿用；GitHub 不提供既有 secret 值的讀回或複製功能。
-- 日後輪替 PAT 時，可改存為同名 environment secrets；environment secrets 會覆蓋同名 repository secrets。
+- VS Code Marketplace 使用 Microsoft Entra workload identity federation，不保存 `VSCE_PAT`。在 environment variables 設定 `AZURE_CLIENT_ID` 與 `AZURE_TENANT_ID`；這兩項是識別碼，不是秘密。
+- Open VSX 仍使用 `OVSX_PAT` environment secret；GitHub 不提供既有 secret 值的讀回或複製功能。
 - Deployment branches and tags 限制為 `v*` tags 與受保護的 `master` branch；`master` 僅供不可變 tag 與原 run artifact 的復原 workflow 使用。
 - 不新增 environment reviewer；人工發布核准由 `pr-review-release` Phase 3.5 負責。
+
+### VS Code Marketplace Entra 身分
+
+- Azure 資源群組為 `rg-singular-blockly-release`，user-assigned managed identity 為 `singular-blockly-marketplace-publisher`。
+- Federated credential 的 issuer 為 GitHub Actions，audience 為 `api://AzureADTokenExchange`，subject 只允許 `Shen-Ming-Hong/singular-blockly` 的 `release` environment；Azure 入口網站產生的 subject 同時固定 GitHub owner 與 repository 的 immutable numeric ID，避免名稱刪除後被冒用。
+- 該身分不需要 Azure subscription 或 resource group RBAC；`azure/login` 使用 `allow-no-subscriptions: true`，權限只來自 Marketplace publisher 的 Contributor 成員資格。
+- `.github/workflows/verify-marketplace-identity.yml` 只在人工觸發時登入該身分並解析 Marketplace User ID，不會封裝或發布 extension。第一次以 `verify_membership=false` 取得 User ID，將其加入 Marketplace publisher `Singular-Ray` 並設為 Contributor；第二次以 `verify_membership=true` 執行唯讀的 `vsce verify-pat`。
+- `.github/workflows/publish.yml` 只在 `publish-marketplace` job 授予 `id-token: write`，使用固定 commit SHA 的 `azure/login`，先執行 `vsce verify-pat Singular-Ray --azure-credential`，再以同一短效身分發布。
+- 身分驗證與一次不發布的檢查成功後，應撤銷／刪除舊 `VSCE_PAT`；不要把 Entra access token、Azure CLI cache 或 Marketplace 短效憑證存進 secret、artifact 或 log。
 
 ### `master` ruleset
 
@@ -116,8 +125,8 @@ gh workflow run recover-github-release.yml --ref master \
 
 ## Secrets 與權限
 
-- Secrets 名稱維持 `VSCE_PAT`、`OVSX_PAT`，不得寫入 log、artifact 或 repository。
+- 長期發布 secret 只保留 Open VSX 的 `OVSX_PAT`，不得寫入 log、artifact 或 repository；VS Code Marketplace 改用 GitHub OIDC 取得 Entra 短效權杖。
 - Workflow 預設只有 `contents: read`。
-- 只有 GitHub Release job 使用 `contents: write`；翻譯驗證不使用寫入權限。
+- 只有 GitHub Release job 使用 `contents: write`；只有 Marketplace 身分驗證／發布 job 使用 `id-token: write`；翻譯驗證不使用寫入權限。
 - 所有第三方 Actions 固定完整 commit SHA，Dependabot 每週追蹤 npm 與 GitHub Actions 更新。
 - 帳號、Copilot 與硬體 integration tests 保留在發布技能的人工驗收，不放入無憑證 CI。

--- a/scripts/release/prepare-release.test.js
+++ b/scripts/release/prepare-release.test.js
@@ -125,6 +125,10 @@ describe('release preparation', () => {
 
 describe('publish workflow retry contract', () => {
 	const workflow = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'workflows', 'publish.yml'), 'utf8');
+	const identityWorkflow = fs.readFileSync(
+		path.join(__dirname, '..', '..', '.github', 'workflows', 'verify-marketplace-identity.yml'),
+		'utf8'
+	);
 	const runtimeWorkflow = fs.readFileSync(
 		path.join(__dirname, '..', '..', '.github', 'workflows', 'runtime-installation.yml'),
 		'utf8'
@@ -157,6 +161,29 @@ describe('publish workflow retry contract', () => {
 		const retrySteps = workflow.match(/if: github\.run_attempt > 1[\s\S]*?run: [^\n]+/gu) || [];
 		assert.strictEqual(retrySteps.length, 2);
 		assert.ok(retrySteps.every(step => step.includes('--skip-duplicate')));
+	});
+
+	it('uses Entra workload identity for Marketplace publishing without a VSCE PAT', () => {
+		const marketplaceJob = workflow.match(/  publish-marketplace:[\s\S]*?(?=\n  publish-open-vsx:)/u)?.[0];
+		assert.ok(marketplaceJob);
+		assert.match(marketplaceJob, /id-token: write/);
+		assert.match(marketplaceJob, /azure\/login@[0-9a-f]{40} # v3\.0\.1/);
+		assert.match(marketplaceJob, /client-id: \$\{\{ vars\.AZURE_CLIENT_ID \}\}/);
+		assert.match(marketplaceJob, /allow-no-subscriptions: true/);
+		assert.ok(!marketplaceJob.includes('subscription-id:'));
+		assert.match(marketplaceJob, /vsce verify-pat Singular-Ray --azure-credential/);
+		assert.strictEqual((marketplaceJob.match(/vsce publish --azure-credential/gu) || []).length, 2);
+		assert.ok(!marketplaceJob.includes('VSCE_PAT'));
+	});
+
+	it('keeps the Marketplace identity resolver non-publishing', () => {
+		assert.match(identityWorkflow, /workflow_dispatch:/);
+		assert.match(identityWorkflow, /verify_membership:/);
+		assert.match(identityWorkflow, /id-token: write/);
+		assert.match(identityWorkflow, /_apis\/profile\/profiles\/me/);
+		assert.match(identityWorkflow, /vsce verify-pat Singular-Ray --azure-credential/);
+		assert.ok(!identityWorkflow.includes('vsce publish'));
+		assert.ok(!identityWorkflow.includes('ovsx publish'));
 	});
 
 	it('provides explicit repository context to GitHub CLI jobs', () => {


### PR DESCRIPTION
## 變更摘要

- 將 VS Code Marketplace 發布改為 Entra workload identity federation
- 新增不發布套件的 Marketplace 身分與成員資格驗證工作流程
- 補上 release contract 測試與 CI/CD 文件

## 驗證

- npm run lint:release
- npm run test:release（25 passing）
- YAML 解析與 git diff --check
- 本機靜態 Code Review：CLEAR

## 安全與發布界線

此 PR 不建立 tag、不上傳 VSIX、不發布 Marketplace 或 Open VSX；合併後只會再手動執行非發布的身分驗證工作流程。