### PR TITLE
ci(deps): 更新 Azure Login 至 3.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
         run: npm ci
 
       - name: Sign in to Azure with the Marketplace publishing identity
-        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/verify-marketplace-identity.yml
+++ b/.github/workflows/verify-marketplace-identity.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     steps:
       - name: Sign in to Azure with the Marketplace publishing identity
-        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/scripts/release/prepare-release.test.js
+++ b/scripts/release/prepare-release.test.js
@@ -167,7 +167,7 @@ describe('publish workflow retry contract', () => {
 		const marketplaceJob = workflow.match(/  publish-marketplace:[\s\S]*?(?=\n  publish-open-vsx:)/u)?.[0];
 		assert.ok(marketplaceJob);
 		assert.match(marketplaceJob, /id-token: write/);
-		assert.match(marketplaceJob, /azure\/login@[0-9a-f]{40} # v3\.0\.1/);
+		assert.match(marketplaceJob, /azure\/login@[0-9a-f]{40} # v3\.0\.2/);
 		assert.match(marketplaceJob, /client-id: \$\{\{ vars\.AZURE_CLIENT_ID \}\}/);
 		assert.match(marketplaceJob, /allow-no-subscriptions: true/);
 		assert.ok(!marketplaceJob.includes('subscription-id:'));


### PR DESCRIPTION
## 變更摘要 Summary

以 human-owned replacement 取代 Dependabot PR #144。原 PR 只更新 workflow pin，但 repository 的 release contract 仍固定預期 v3.0.1，導致 CI Gate 必然失敗。

## 變更內容 Changes

- 將發布 workflow 的 `azure/login` 更新至 v3.0.2，固定完整 commit SHA `7ddb5af1ef8758cf1353cf3b42f940aee27ba21c`
- 將 Marketplace 身分驗證 workflow 同步至相同 SHA
- 更新 release contract test 的預期版本至 v3.0.2

## 相關項目 Related

- Supersedes #144
- SDD: No SDD；行為與架構契約不變，僅更新 GitHub Action SHA 與對應測試契約

## 安全與供應鏈 Security

- Dependabot Security Alerts：0
- `npm audit`：0 vulnerabilities
- 已核對 Azure/login 官方 v3.0.2 annotated tag 指向上述完整 SHA
- upstream tag／commit 未簽章；以官方 repository 與完整 SHA pin 限制供應鏈風險
- OIDC 權限、secret 來源與 workflow expressions 均未變更

## 驗證 Test Plan

- [x] Workflow YAML parse
- [x] `npm ci`
- [x] `npm audit`
- [x] `npm run test:release`（25 passing）
- [x] `npm run ci:static`
- [x] `npm run test:unit:ci`（1363 passing，1 pending）
- [x] `npm run release:prepare`
- [x] 本地 code review：CLEAR（0 findings）

## 發布資訊 Release Metadata

- 例行 Version Update，不更新 extension 版本或 CHANGELOG
- 不建立 tag、不觸發發布
