### PR TITLE
chore(deps): 更新 Wrangler 至 4.127.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"vitest": "^4.1.11",
 				"webpack": "^5.109.2",
 				"webpack-cli": "^7.2.2",
-				"wrangler": "^4.124.0"
+				"wrangler": "^4.127.0"
 			},
 			"engines": {
 				"node": ">=22.16.0",
@@ -382,6 +382,42 @@
 				"@vitest/runner": "^4.1.0",
 				"@vitest/snapshot": "^4.1.0",
 				"vitest": "^4.1.0"
+			}
+		},
+		"node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+			"version": "4.124.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+			"integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@cloudflare/kv-asset-handler": "0.5.0",
+				"@cloudflare/unenv-preset": "2.16.1",
+				"blake3-wasm": "2.1.5",
+				"esbuild": "0.28.1",
+				"miniflare": "5.20260815.0-alpha",
+				"path-to-regexp": "6.3.0",
+				"unenv": "2.0.0-rc.24",
+				"workerd": "1.20260815.1"
+			},
+			"bin": {
+				"cf-wrangler": "bin/cf-wrangler.js",
+				"wrangler": "bin/wrangler.js",
+				"wrangler2": "bin/wrangler.js"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.3"
+			},
+			"peerDependencies": {
+				"@cloudflare/workers-types": "^5.20260815.1"
+			},
+			"peerDependenciesMeta": {
+				"@cloudflare/workers-types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
@@ -11979,9 +12015,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/wrangler": {
-			"version": "4.124.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
-			"integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
+			"version": "4.127.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.0.tgz",
+			"integrity": "sha512-4dPqcBEMJfGeZeNnjHT7ThNJs+EiNYxUTg4ywqIdQubcXHBhFeVMQyHV4A9AOhZRFr83cckqdds034KGcr/dtw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -11989,10 +12025,10 @@
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.28.1",
-				"miniflare": "5.20260815.0-alpha",
+				"miniflare": "5.20260826.0-alpha",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260815.1"
+				"workerd": "1.20260826.1"
 			},
 			"bin": {
 				"cf-wrangler": "bin/cf-wrangler.js",
@@ -12006,12 +12042,136 @@
 				"fsevents": "2.3.3"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^5.20260815.1"
+				"@cloudflare/workers-types": "^5.20260826.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20260826.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260826.1.tgz",
+			"integrity": "sha512-8UsGGY8ZUiYHOWdsxBlNsGmaHBGArVwJ3CM4nWpfBhthjjYe4M/OqrTpqKF7NNWb63qQiv1d8Z+Z6/hmUqNKIQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20260826.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260826.1.tgz",
+			"integrity": "sha512-0bLqVQYsQ3v3FdYGmzh23vi9fJeYTBx19o4LUySIsRcgBggGSlR39ml162vTXvZzUISOjVW2qfL7Y+SMrrfXmQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20260826.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260826.1.tgz",
+			"integrity": "sha512-DTC0yWzybX4gUH5Q1pJo3UwEQjp0Gmz0Q71I+39xT9SXBesX5QndOIQv45yHQ86Z84EzK2WwaENdlpmDSvJKmw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20260826.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260826.1.tgz",
+			"integrity": "sha512-PFerWi+DP2Ckc6eATAS4dhotBt8IeXJjTzIgy18H+uqsswlXc7A8HsnAunHL9v/7/BjCgq46iMo2g4iUAsEpDw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20260826.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260826.1.tgz",
+			"integrity": "sha512-X26hulrG2MSSfpRmjZbCq98LNaZnrRqbmGcgo7g1U/U0nJ5npYruPm3fAyZ2y6VDr5CmQo9BLCahxP8VB/QR6A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/wrangler/node_modules/miniflare": {
+			"version": "5.20260826.0-alpha",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260826.0-alpha.tgz",
+			"integrity": "sha512-ZXR3Bieg+B5MK0T/zYIWaZiCGCb9Z3en4+/TleYKhIGPLx/e0cRcG/ZvvTviUapVBBK2zODB+aiypdIojU3x6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
+				"sharp": "0.35.2",
+				"undici": "7.29.0",
+				"workerd": "1.20260826.1",
+				"ws": "8.21.0",
+				"youch": "4.1.0-beta.10"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/wrangler/node_modules/workerd": {
+			"version": "1.20260826.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260826.1.tgz",
+			"integrity": "sha512-oTG9ot5zxO9OjjKCskt86+nVrBL0kiUqExHnYaTg4OCkHf/K4zr+9hYvgwmG8DdCWG0TQGErHzD+1h50TM5b+w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20260826.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260826.1",
+				"@cloudflare/workerd-linux-64": "1.20260826.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260826.1",
+				"@cloudflare/workerd-windows-64": "1.20260826.1"
 			}
 		},
 		"node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
 		"vitest": "^4.1.11",
 		"webpack": "^5.109.2",
 		"webpack-cli": "^7.2.2",
-		"wrangler": "^4.124.0"
+		"wrangler": "^4.127.0"
 	},
 	"dependencies": {
 		"@blockly/theme-modern": "^13.2.0",


### PR DESCRIPTION
## 變更摘要 Summary

將根層級開發相依套件 Wrangler 從 4.124.0 更新至 4.127.0，作為 Dependabot #146 中 Wrangler 部分的獨立替代 PR。

原始 #146 仍包含 webpack 與 @types/vscode，合併本 PR 後應重新分流，不由本 PR 自動關閉。

## 變更內容 Changes

- 更新 package.json 的 Wrangler 範圍至 ^4.127.0
- 更新 package-lock.json 並固定 npm registry integrity
- 保留 @cloudflare/vitest-pool-workers 精確相依的巢狀 Wrangler 4.124.0
- 不修改 webpack、@types/vscode、產品版本或 CHANGELOG

## SDD 與發布 SDD and Release

- SDD：不需要；這是無產品行為變更的單一開發工具相依更新
- Release：不適用；不建立版本、tag 或 Marketplace 發布

## 驗證 Test Plan

- [x] npm ci
- [x] npm audit（0 vulnerabilities）
- [x] npm run ci:static
- [x] npm run test:unit:ci（1363 passing、1 pending）
- [x] npm run test:release
- [x] npm run release:prepare -- --verify-files
- [x] npm run feedback:typecheck
- [x] npm run feedback:test（152 passing）
- [x] Wrangler deploy --dry-run
- [x] VSIX package、privacy verification 與 managed-runtime smoke

## 審查 Review

- local-code-review-loop：CLEAR
- code-simplifier：不適用（沒有 TS/JS 變更）
- Security：npm audit 0；lockfile 使用 registry integrity

## 既有事項 Existing Follow-up

Wrangler types 的暫存試跑成功，但顯示既有 worker-configuration.d.ts 與初始 #142 config 的 Access team domain 漂移，以及新版 Workerd runtime types 的大量產生差異。為維持此 PR 的單一依賴範圍，本 PR 不修改該產生檔，後續另案處理。

Related: #146