### PR TITLE
chore(deps): 更新 webpack 至 5.110.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"ts-loader": "^9.6.2",
 				"typescript": "^6.0.3",
 				"vitest": "^4.1.11",
-				"webpack": "^5.109.2",
+				"webpack": "^5.110.1",
 				"webpack-cli": "^7.2.2",
 				"wrangler": "^4.127.0"
 			},
@@ -8513,16 +8513,16 @@
 			}
 		},
 		"node_modules/minimizer-webpack-plugin": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-			"integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.8.0.tgz",
+			"integrity": "sha512-2cT9+goJfBhtMz+gJqejSf09ClgmYhPhccRb/fb0ztVbixt0BkO8mRuI26FoPPuUNkRk6iEDryWAIouc5W8eJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@jridgewell/trace-mapping": "^0.3.31",
 				"jest-worker": "^27.4.5",
-				"schema-utils": "^4.3.0",
-				"terser": "^5.31.1"
+				"schema-utils": "^4.3.3",
+				"terser": "^5.51.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -11025,9 +11025,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.49.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.49.2.tgz",
-			"integrity": "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==",
+			"version": "5.51.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+			"integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -11738,9 +11738,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.109.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
-			"integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
+			"version": "5.110.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
+			"integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11754,11 +11754,10 @@
 				"chrome-trace-event": "^1.0.2",
 				"enhanced-resolve": "^5.24.4",
 				"es-module-lexer": "^2.1.0",
-				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"graceful-fs": "^4.2.11",
 				"mime-db": "^1.54.0",
-				"minimizer-webpack-plugin": "^5.6.1",
+				"minimizer-webpack-plugin": "^5.7.0",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
@@ -11865,28 +11864,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/webpack/node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/webpack/node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/webpack/node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
 		"ts-loader": "^9.6.2",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.11",
-		"webpack": "^5.109.2",
+		"webpack": "^5.110.1",
 		"webpack-cli": "^7.2.2",
 		"wrangler": "^4.127.0"
 	},


### PR DESCRIPTION
## 變更摘要 Summary

- 將 webpack 從 5.109.2 更新至 5.110.1。
- 此 PR 是 Dependabot #149 中 webpack 部分的人工維護替代 PR。
- #149 仍包含與 engines.vscode ^1.109.0 不相容的 @types/vscode 1.134.0，因此本 PR 不會自動關閉 #149。

## 規劃與相容性 Planning and compatibility

- 分類：P2 Version Update，採 Lightweight Plan，無需完整 SDD 規格。
- 本次僅更新依賴與 lockfile，不包含產品原始碼、版本號、CHANGELOG 或發布動作。
- webpack、terser 與 minimizer-webpack-plugin 的 Node.js engines 均涵蓋專案 Node.js 22.16.0+ 基準；本機使用 Node.js 25.9.0 驗證，GitHub CI 將以專案固定的 Node.js 22.16.0 再驗證。
- production bundle 由 1,285,652 bytes 降至 1,281,461 bytes，減少 4,191 bytes，約 0.33%。

## 驗證 Validation

- npm ci
- npm audit：0 vulnerabilities
- npm ls webpack webpack-cli ts-loader minimizer-webpack-plugin terser
- npm run compile
- npm run package
- npm run ci:static
- npm run test:unit:ci：1363 passing，1 pending
- feedback contract tests：20 files，152 tests passing
- npm run release:prepare
- npm run test:managed-runtime:paths
- VSIX privacy verification 與 managed-runtime VSIX verification
- 本地 Code Review：CLEAR，無 P0-P3 finding
- security-checker：未發現新增安全風險或安裝腳本