### PR TITLE
chore(deps): 修補 v0.88.1 相依套件漏洞

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.88.1] - 2026-09-04
+
+### 🔒 安全性 Security
+
+- 將間接開發相依的 `fast-uri` override 從 3.1.5 升級至 3.1.7，修復四項 CVSS 7.5 host confusion／SSRF 高風險漏洞（CVE-2026-75931、CVE-2026-75899、CVE-2026-75975、CVE-2026-76172），以及兩項新增的 authority injection／IP-literal bracket host confusion 高風險公告（GHSA-qw65-cvwx-89v3、GHSA-58mr-gqgx-xq4g）；並關閉 Dependabot Alerts #105、#106、#108 與 #109
+  Upgraded the transitive development dependency `fast-uri` override from 3.1.5 to 3.1.7, fixing four CVSS 7.5 high-severity host-confusion/SSRF vulnerabilities (CVE-2026-75931, CVE-2026-75899, CVE-2026-75975, and CVE-2026-76172) plus two newly disclosed high-severity authority-injection/IP-literal-bracket host-confusion advisories (GHSA-qw65-cvwx-89v3 and GHSA-58mr-gqgx-xq4g), and closing Dependabot Alerts #105, #106, #108, and #109
+- 將間接開發相依 `browserslist` 從 4.28.1 升級至 4.28.7，修復未限制快取記憶體成長與不可信自訂統計造成的崩潰／prototype write 高風險漏洞（CVE-2026-73089、CVE-2026-73088；CVSS 7.5）
+  Upgraded the transitive development dependency `browserslist` from 4.28.1 to 4.28.7, fixing high-severity unbounded cache growth and untrusted custom-stat crash/prototype-write vulnerabilities (CVE-2026-73089 and CVE-2026-73088; CVSS 7.5)
+- 將間接開發相依的 `qs` override 從 6.15.2 升級至 6.16.0，修復 array-limit bypass 與攻擊者控制 `isBuffer` 造成的中風險拒絕服務漏洞（CVE-2026-82562，CVSS 3.7；CVE-2026-82417，CVSS 5.3）
+  Upgraded the transitive development dependency `qs` override from 6.15.2 to 6.16.0, fixing medium-severity denial-of-service vulnerabilities caused by an array-limit bypass and attacker-controlled `isBuffer` handling (CVE-2026-82562, CVSS 3.7; CVE-2026-82417, CVSS 5.3)
+
 ## [0.88.0] - 2026-08-26
 
 ### ✨ 新增功能 Features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,10 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 | Package  | Severity | Advisory | Reason                                                    |
 | -------- | -------- | -------- | --------------------------------------------------------- |
-| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.88.0 |
+| _(none)_ | —        | —        | All known vulnerabilities have been resolved as of 0.88.1 |
+
+> **0.88.1 更新 Update**: 間接開發相依 `fast-uri` 升級至 `3.1.7`，修復 Dependabot Alerts #105、#106、#108 與 #109 的四項高風險 host confusion／SSRF 漏洞，以及 GHSA-qw65-cvwx-89v3 與 GHSA-58mr-gqgx-xq4g 的兩項新增高風險公告；`browserslist` 升級至 `4.28.7`，修復兩項高風險記憶體耗盡與 prototype-write 漏洞；`qs` 升級至 `6.16.0`，修復兩項中風險拒絕服務漏洞。本地 `npm audit` 顯示 0 vulnerabilities。
+> Transitive development dependency `fast-uri` was upgraded to `3.1.7`, fixing four high-severity host-confusion/SSRF vulnerabilities in Dependabot Alerts #105, #106, #108, and #109 plus two newly disclosed high-severity advisories, GHSA-qw65-cvwx-89v3 and GHSA-58mr-gqgx-xq4g; `browserslist` was upgraded to `4.28.7`, fixing two high-severity memory-exhaustion and prototype-write vulnerabilities; `qs` was upgraded to `6.16.0`, fixing two medium-severity denial-of-service vulnerabilities. Local `npm audit` reports 0 vulnerabilities.
 
 > **0.88.0 更新 Update**: 公開回報編號的 32 字元均勻映射改用等價位元遮罩，消除 GitHub Code Scanning Alert #19（CodeQL `js/biased-cryptographic-random`）並以固定邊界位元組補足回歸測試。
 > Public feedback references now map random bytes uniformly to the 32-character alphabet with an equivalent bit mask, resolving GitHub Code Scanning Alert #19 (CodeQL `js/biased-cryptographic-random`) with regression coverage for boundary bytes.
@@ -67,4 +70,4 @@ Please report security vulnerabilities by opening a [GitHub Security Advisory](h
 
 ---
 
-_Last updated: 2026-08-26_
+_Last updated: 2026-09-04_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "singular-blockly",
-	"version": "0.88.0",
+	"version": "0.88.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "singular-blockly",
-			"version": "0.88.0",
+			"version": "0.88.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^13.2.0",
@@ -4859,13 +4859,16 @@
 			"optional": true
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.19",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-			"integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+			"version": "2.11.21",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+			"integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/bcrypt-pbkdf": {
@@ -5008,9 +5011,9 @@
 			"license": "ISC"
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"version": "4.28.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+			"integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5028,11 +5031,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
+				"baseline-browser-mapping": "^2.10.44",
+				"caniuse-lite": "^1.0.30001806",
+				"electron-to-chromium": "^1.5.393",
+				"node-releases": "^2.0.51",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -5290,9 +5293,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001769",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-			"integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+			"version": "1.0.30001810",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+			"integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6117,9 +6120,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.286",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-			"integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+			"version": "1.5.421",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.421.tgz",
+			"integrity": "sha512-cUhfpHQy+PGbt+X90DMcAVazDCziIZr73hpxD4LRs4BGQoJCifPzTfQWa7S6c+uhokTOBe8tot09GBSEO6c9LA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6647,9 +6650,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+			"integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
 			"dev": true,
 			"funding": [
 				{
@@ -8948,11 +8951,14 @@
 			"optional": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"version": "2.0.54",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+			"integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/node-sarif-builder": {
 			"version": "3.4.0",
@@ -9768,13 +9774,14 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -10304,15 +10311,15 @@
 			"license": "MIT"
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "singular-blockly",
 	"displayName": "Singular Blockly",
 	"description": "VS Code extension for visual Arduino & MicroPython programming with Blockly. Multi-board support, project-local Agent Skills, AI camera integration, PlatformIO integration, and 15 languages.",
-	"version": "0.88.0",
+	"version": "0.88.1",
 	"license": "Apache-2.0",
 	"engines": {
 		"vscode": "^1.109.0",
@@ -316,9 +316,9 @@
 	},
 	"overrides": {
 		"js-yaml": "^5.2.2",
-		"qs": "^6.15.2",
+		"qs": "^6.16.0",
 		"serialize-javascript": "^7.0.5",
-		"fast-uri": "^3.1.5",
+		"fast-uri": "^3.1.7",
 		"diff": ">=8.0.3",
 		"flatted": ">=3.4.0",
 		"picomatch": "2.3.2",


### PR DESCRIPTION
## 變更摘要 Summary

準備 v0.88.1 P0 安全修補，更新間接開發相依並同步版本與雙語安全文件。

Prepare the v0.88.1 P0 security patch by updating transitive development dependencies and synchronizing release metadata and bilingual security documentation.

## 安全修補 Security Fixes

- `fast-uri` 3.1.5 → 3.1.7：修復 Dependabot Alerts #105、#106、#108、#109，以及兩項新增 High 公告。
- `browserslist` 4.28.1 → 4.28.7：修復兩項 High 漏洞。
- `qs` 6.15.2 → 6.16.0：修復兩項 Medium 漏洞。
- 本地 `npm audit`：0 vulnerabilities。

## 變更類型 Type of Change

- [x] 安全性修補 Security patch
- [x] 相依套件更新 Dependency update
- [x] 發布文件更新 Release documentation
- [ ] 使用者介面變更 User interface change

## 測試計劃 Test Plan

- [x] `npm ci --no-audit`
- [x] `npm run ci:static`
- [x] `npm run test:unit:ci`（1,363 passing、1 pending）
- [x] `npm run test:release`（25 passing）
- [x] `npm run release:prepare`
- [x] `npm run validate:i18n`
- [x] i18n JSON gate（15 locales、0 errors）
- [x] `git diff --check`
- [x] 本地 Code Review：CLEAR

## 發布資訊 Release Metadata

- Version: `v0.88.1`
- `package.json`、`package-lock.json`、雙語 `CHANGELOG.md` 與 `SECURITY.md` 已包含於本 PR。
- 無 UI 變更，不需螢幕截圖。
