### PR TITLE
chore(deps): 更新建置與 lint 工具相依套件

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
 				"@types/node": "^22.0.0",
 				"@types/sinon": "^22.0.0",
 				"@types/vscode": "^1.109.0",
-				"@typescript-eslint/eslint-plugin": "^8.68.0",
-				"@typescript-eslint/parser": "^8.68.0",
+				"@typescript-eslint/eslint-plugin": "^8.69.0",
+				"@typescript-eslint/parser": "^8.69.0",
 				"@vscode/test-cli": "^0.0.15",
 				"@vscode/test-electron": "^3.1.0",
 				"@vscode/vsce": "3.9.2",
@@ -37,8 +37,8 @@
 				"ts-loader": "^9.6.2",
 				"typescript": "^6.0.3",
 				"vitest": "^4.1.11",
-				"webpack": "^5.110.1",
-				"webpack-cli": "^7.2.2",
+				"webpack": "^5.110.3",
+				"webpack-cli": "^7.2.3",
 				"wrangler": "^4.127.0"
 			},
 			"engines": {
@@ -3783,17 +3783,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
-			"integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+			"integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.68.0",
-				"@typescript-eslint/type-utils": "8.68.0",
-				"@typescript-eslint/utils": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0",
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/type-utils": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -3806,22 +3806,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.68.0",
+				"@typescript-eslint/parser": "^8.69.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
-			"integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+			"integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.68.0",
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/typescript-estree": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0",
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3837,14 +3837,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
-			"integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+			"integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.68.0",
-				"@typescript-eslint/types": "^8.68.0",
+				"@typescript-eslint/tsconfig-utils": "^8.69.0",
+				"@typescript-eslint/types": "^8.69.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3859,14 +3859,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
-			"integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+			"integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0"
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3877,9 +3877,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
-			"integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+			"integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3894,15 +3894,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
-			"integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+			"integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/typescript-estree": "8.68.0",
-				"@typescript-eslint/utils": "8.68.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -3919,9 +3919,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
-			"integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+			"integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3933,16 +3933,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
-			"integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+			"integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.68.0",
-				"@typescript-eslint/tsconfig-utils": "8.68.0",
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0",
+				"@typescript-eslint/project-service": "8.69.0",
+				"@typescript-eslint/tsconfig-utils": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -3961,16 +3961,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
-			"integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+			"integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.68.0",
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/typescript-estree": "8.68.0"
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3985,13 +3985,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
-			"integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+			"integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.68.0",
+				"@typescript-eslint/types": "8.69.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -11745,9 +11745,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.110.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
-			"integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
+			"version": "5.110.3",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
+			"integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11788,9 +11788,9 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.2.tgz",
-			"integrity": "sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.3.tgz",
+			"integrity": "sha512-vDFU7jrfCctnN7jJQWPl+V26B51GLp11prVZXg50oeonsgeBzSTJEWmXkjHsOjTgMjlPOQM8GWLh33X9RN/0ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11816,7 +11816,7 @@
 			"peerDependencies": {
 				"js-yaml": "^4.0.0 || ^5.0.0",
 				"json5": "^2.2.3",
-				"toml": "^3.0.0 || ^4.0.0",
+				"toml": "^3.0.0 || ^4.0.0 || ^5.0.0",
 				"webpack": "^5.101.0",
 				"webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
 				"webpack-dev-server": "^5.0.0 || ^6.0.0"

--- a/package.json
+++ b/package.json
@@ -287,8 +287,8 @@
 		"@types/node": "^22.0.0",
 		"@types/sinon": "^22.0.0",
 		"@types/vscode": "^1.109.0",
-		"@typescript-eslint/eslint-plugin": "^8.68.0",
-		"@typescript-eslint/parser": "^8.68.0",
+		"@typescript-eslint/eslint-plugin": "^8.69.0",
+		"@typescript-eslint/parser": "^8.69.0",
 		"@vscode/test-cli": "^0.0.15",
 		"@vscode/test-electron": "^3.1.0",
 		"@vscode/vsce": "3.9.2",
@@ -303,8 +303,8 @@
 		"ts-loader": "^9.6.2",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.11",
-		"webpack": "^5.110.1",
-		"webpack-cli": "^7.2.2",
+		"webpack": "^5.110.3",
+		"webpack-cli": "^7.2.3",
 		"wrangler": "^4.127.0"
 	},
 	"dependencies": {


### PR DESCRIPTION
將 Dependabot #153 的建置與 lint 更新拆成獨立 PR，更新 `@typescript-eslint/eslint-plugin`／`@typescript-eslint/parser` 8.68.0 → 8.69.0、webpack 5.110.1 → 5.110.3、webpack-cli 7.2.2 → 7.2.3。同步更新兩個 typescript-eslint manifest 下限及 lockfile 中的同版本子套件。

這是例行 Version Update，SDD 判斷為 No SDD。差異僅有 package.json 與 package-lock.json；VS Code 最低支援版本、runtime 依賴與擴充套件版本 0.88.1 維持現況。

相關來源：https://github.com/Shen-Ming-Hong/singular-blockly/pull/153 。此 PR 僅涵蓋該 grouped PR 的四項更新，其餘更新仍需分開處理。

驗證環境：macOS arm64、Node.js 22.16.0、VS Code 1.109.0。

- `npm ci` 通過；`npm audit` 為 0。
- `npm ls @typescript-eslint/eslint-plugin @typescript-eslint/parser webpack webpack-cli` 通過，無 peer mismatch。
- `npm run ci:static` 通過，含 Worker 152 tests、release 25 tests、i18n 與 Skill 契約檢查。
- `npm run test:unit:ci`：1363 passing、1 pending（既有跳過的 AI suggestion 測試）。
- `npm run package` production bundle 建置通過。
- `npm run release:prepare` 通過；未建立正式 VSIX 或 tag。
- 本地 review：CLEAR，範圍為 1a4a4d2...878eb52 的兩個版本檔；12 個變動 lockfile 套件條目均為目標 dev 套件，無套件新增／移除或 runtime 依賴變動。

遠端 PR CI／封裝 smoke test 待建立 PR 後執行。
