### PR TITLE
chore(deps): 更新 proxy-agent 至 0.45.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@blockly/theme-modern": "^13.2.0",
-				"@vscode/proxy-agent": "0.44.0",
+				"@vscode/proxy-agent": "0.45.0",
 				"form-data": "^4.0.6",
 				"node-ssh": "^13.2.1",
 				"tar": "7.5.22"
@@ -4144,9 +4144,9 @@
 			}
 		},
 		"node_modules/@vscode/proxy-agent": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@vscode/proxy-agent/-/proxy-agent-0.44.0.tgz",
-			"integrity": "sha512-1vv0uJrIGxS89C+0gPmgNuOcw+Pjw0h7y0U3/l7pfwuiDq2Ua3evUVAkDj86v/Mn+UuFn20MWA04YyZ4huJcOA==",
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/@vscode/proxy-agent/-/proxy-agent-0.45.0.tgz",
+			"integrity": "sha512-rSR81pniNECvd3Zr1sq0VqYL7H+02dT723sEexpoweWi9mMklwLoapHTkwK6nAtxhjXNagRkT7l2GWuripXD7Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/once": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
 	},
 	"dependencies": {
 		"@blockly/theme-modern": "^13.2.0",
-		"@vscode/proxy-agent": "0.44.0",
+		"@vscode/proxy-agent": "0.45.0",
 		"form-data": "^4.0.6",
 		"node-ssh": "^13.2.1",
 		"tar": "7.5.22"


### PR DESCRIPTION
將 `@vscode/proxy-agent` 從 0.44.0 更新至 0.45.0，從 Dependabot #156（接續已關閉的 #153）拆成獨立 runtime 依賴更新。差異僅有 package.json 的精確版本與 lockfile 對應條目，沒有其他依賴漂移。

官方 0.45.0 將 macOS 的 Node 系統憑證載入移到 worker。專案現有 adapter 明確停用 addCertificatesV1、addCertificatesV2 與 loadSystemCertificatesFromNode，因此這條新增 worker 路徑不會啟用，既有 Node trust store 與 NODE_EXTRA_CA_CERTS 行為保留。Node >=22.15.0 的要求符合專案 22.16.0 基線。

SDD：No SDD，公開 API 與產品契約無需修改。這是例行 Version Update，擴充套件維持 0.88.1。

驗證環境：macOS arm64、Node.js 22.16.0、VS Code 1.109.0。

- npm ci、npm ls 通過；npm audit 為 0。
- npm run ci:static 通過，包含 Worker 152 tests、release 25 tests 與 i18n／Skill 契約。
- npm run test:unit:ci：1363 passing、1 pending（需互動登入的既有 AI 測試）。
- npm run package production bundle 與 npm run release:prepare 通過。
- 暫存 smoke harness 驗證 7 項行為：設定代理與 HTTPS_PROXY 使用本地 CONNECT proxy；NO_PROXY、設定 noProxy、proxySupport off 回到原 fetch；本地 HTTPS 拒絕不可信憑證，子程序設定 NODE_EXTRA_CA_CERTS 後成功。Bypass 測試使用注入 fetch；CONNECT 與 TLS 使用真實 loopback sockets。
- 本地 review：CLEAR；僅兩個版本檔，無 TS／JS 簡化項目，未使用額外雲端 reviewer。

遠端 CI、CodeQL 與 VSIX smoke test 待 PR 建立後執行。本地未建立正式 VSIX 或 tag。

來源：[原始 grouped PR #153](https://github.com/Shen-Ming-Hong/singular-blockly/pull/153)、[接續 PR #156](https://github.com/Shen-Ming-Hong/singular-blockly/pull/156)、[官方版本差異](https://github.com/microsoft/vscode-proxy-agent/compare/v0.44.0...v0.45.0)。
