### PR TITLE
chore(deps): 更新 Wrangler 至 4.129.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"vitest": "^4.1.11",
 				"webpack": "^5.110.3",
 				"webpack-cli": "^7.2.3",
-				"wrangler": "^4.127.0"
+				"wrangler": "^4.129.0"
 			},
 			"engines": {
 				"node": ">=22.16.0",
@@ -11999,9 +11999,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/wrangler": {
-			"version": "4.127.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.0.tgz",
-			"integrity": "sha512-4dPqcBEMJfGeZeNnjHT7ThNJs+EiNYxUTg4ywqIdQubcXHBhFeVMQyHV4A9AOhZRFr83cckqdds034KGcr/dtw==",
+			"version": "4.129.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz",
+			"integrity": "sha512-PGPvs9UPoFrwxT0VogpESSZGvZIctAuTK3wGsLLPHtHsSgS85kNdvtpa2d14UzG8gwLWD64XUGFPGG9tOXG9VQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -12009,10 +12009,10 @@
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.28.1",
-				"miniflare": "5.20260826.0-alpha",
+				"miniflare": "5.20260903.0-alpha",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260826.1"
+				"workerd": "1.20260903.1"
 			},
 			"bin": {
 				"cf-wrangler": "bin/cf-wrangler.js",
@@ -12026,7 +12026,7 @@
 				"fsevents": "2.3.3"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^5.20260826.1"
+				"@cloudflare/workers-types": "^5.20260903.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -12035,9 +12035,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260826.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260826.1.tgz",
-			"integrity": "sha512-8UsGGY8ZUiYHOWdsxBlNsGmaHBGArVwJ3CM4nWpfBhthjjYe4M/OqrTpqKF7NNWb63qQiv1d8Z+Z6/hmUqNKIQ==",
+			"version": "1.20260903.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+			"integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
 			"cpu": [
 				"x64"
 			],
@@ -12052,9 +12052,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260826.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260826.1.tgz",
-			"integrity": "sha512-0bLqVQYsQ3v3FdYGmzh23vi9fJeYTBx19o4LUySIsRcgBggGSlR39ml162vTXvZzUISOjVW2qfL7Y+SMrrfXmQ==",
+			"version": "1.20260903.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+			"integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -12069,9 +12069,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260826.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260826.1.tgz",
-			"integrity": "sha512-DTC0yWzybX4gUH5Q1pJo3UwEQjp0Gmz0Q71I+39xT9SXBesX5QndOIQv45yHQ86Z84EzK2WwaENdlpmDSvJKmw==",
+			"version": "1.20260903.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+			"integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
 			"cpu": [
 				"x64"
 			],
@@ -12086,9 +12086,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260826.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260826.1.tgz",
-			"integrity": "sha512-PFerWi+DP2Ckc6eATAS4dhotBt8IeXJjTzIgy18H+uqsswlXc7A8HsnAunHL9v/7/BjCgq46iMo2g4iUAsEpDw==",
+			"version": "1.20260903.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+			"integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
 			"cpu": [
 				"arm64"
 			],
@@ -12103,9 +12103,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260826.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260826.1.tgz",
-			"integrity": "sha512-X26hulrG2MSSfpRmjZbCq98LNaZnrRqbmGcgo7g1U/U0nJ5npYruPm3fAyZ2y6VDr5CmQo9BLCahxP8VB/QR6A==",
+			"version": "1.20260903.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+			"integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
 			"cpu": [
 				"x64"
 			],
@@ -12120,16 +12120,16 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/miniflare": {
-			"version": "5.20260826.0-alpha",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260826.0-alpha.tgz",
-			"integrity": "sha512-ZXR3Bieg+B5MK0T/zYIWaZiCGCb9Z3en4+/TleYKhIGPLx/e0cRcG/ZvvTviUapVBBK2zODB+aiypdIojU3x6Q==",
+			"version": "5.20260903.0-alpha",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+			"integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "0.35.2",
 				"undici": "7.29.0",
-				"workerd": "1.20260826.1",
+				"workerd": "1.20260903.1",
 				"ws": "8.21.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -12138,9 +12138,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/workerd": {
-			"version": "1.20260826.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260826.1.tgz",
-			"integrity": "sha512-oTG9ot5zxO9OjjKCskt86+nVrBL0kiUqExHnYaTg4OCkHf/K4zr+9hYvgwmG8DdCWG0TQGErHzD+1h50TM5b+w==",
+			"version": "1.20260903.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+			"integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -12151,11 +12151,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260826.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260826.1",
-				"@cloudflare/workerd-linux-64": "1.20260826.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260826.1",
-				"@cloudflare/workerd-windows-64": "1.20260826.1"
+				"@cloudflare/workerd-darwin-64": "1.20260903.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+				"@cloudflare/workerd-linux-64": "1.20260903.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260903.1",
+				"@cloudflare/workerd-windows-64": "1.20260903.1"
 			}
 		},
 		"node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
 		"vitest": "^4.1.11",
 		"webpack": "^5.110.3",
 		"webpack-cli": "^7.2.3",
-		"wrangler": "^4.127.0"
+		"wrangler": "^4.129.0"
 	},
 	"dependencies": {
 		"@blockly/theme-modern": "^13.2.0",


### PR DESCRIPTION
將直接開發依賴 Wrangler 從 4.127.0 更新至 4.129.0，從 Dependabot #156 拆成獨立更新。同步其內含 Miniflare 5.20260903.0-alpha、workerd 1.20260903.1 與各平台二進位套件；沒有其他依賴漂移。

SDD：No SDD。官方 4.128.0 調整的不穩定 binding API 未被專案使用，現有 Worker 設定、型別與產品契約不需修改。Node >=22.0.0 的要求符合專案基線；版本維持 0.88.1。

驗證環境：macOS arm64、Node.js 22.16.0、VS Code 1.109.0。

- npm ci、npm ls wrangler miniflare workerd @cloudflare/vitest-pool-workers 通過；npm audit 為 0。
- npm run ci:static 通過，包含 Worker 152 tests、release 25 tests、型別、i18n 與 Skill 契約。
- npm run test:unit:ci：1363 passing、1 pending（需互動登入的既有 AI 測試）。
- npm run package production bundle 與 npm run release:prepare 通過。
- Wrangler deploy --dry-run 通過；無部署或遠端資料變更。
- 額外使用新版 Wrangler 啟動本地 workerd：/support、/privacy、/terms 回應 200；載入僅本地測試設定後 /health 回應 200、D1 SELECT 1 成功。測試程序與臨時 .dev.vars 已清理。
- 本地 review：CLEAR；兩個版本檔，無 TS／JS 簡化項目，未呼叫額外雲端 reviewer。

驗證限制與既有問題：Vitest pool 0.22.0 使用其自己的舊版 runtime，因此另做上述新版 workerd smoke test。完全缺少本地 secrets 時 /health 回應 500（原預期為 503）；在基準 commit db0b786、Wrangler 4.127.0 的獨立既有乾淨安裝環境也重現 500。原始碼 runtimeConfigIsValid 直接對缺少的 MAINTAINER_ACTOR_IDS 呼叫 split，此既有設定缺漏處理問題不在此次升級範圍；本 PR 沒有修改該行為。

遠端 CI、CodeQL 與 VSIX smoke test 待建立 PR 後執行。本次無正式發布。

來源：[Dependabot #156](https://github.com/Shen-Ming-Hong/singular-blockly/pull/156)、[Wrangler 4.128.0](https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.128.0)、[Wrangler 4.129.0](https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.129.0)。
