### PR TITLE
chore(deps): 隔離 VS Code 型別並整合 Worker 測試更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
       timezone: Asia/Taipei
     open-pull-requests-limit: 10
     groups:
+      worker-tests:
+        patterns:
+          - vitest
+          - "@cloudflare/vitest-pool-workers"
       npm-minor-and-patch:
+        exclude-patterns:
+          - "@types/vscode"
         update-types:
           - minor
           - patch


### PR DESCRIPTION
VS Code 型別更新會超出目前 extension engine 基線並阻塞一般依賴群組；Vitest 更新則需要配合 Cloudflare Worker 測試套件的 peer requirements。

將 `@types/vscode` 排除一般 minor／patch 群組，改為獨立 PR；在一般群組前新增 `worker-tests`，納入 `vitest` 與 `@cloudflare/vitest-pool-workers` 的 major、minor、patch 版本更新。分組不會解決現有 Vitest 5 peer 衝突，仍需等待相容版本並驗證。

只修改 `.github/dependabot.yml`，No SDD。未修改套件版本、ignore、排程或 PR 上限，不包含版本發布。

驗證：YAML 解析與 15 組套件／SemVer 分組檢查通過；確認其餘設定與 base 完全相同；git diff --check 通過。本地審查 CLEAR，外部 reviewer 0 輪，無 TS/JS 簡化需求。程式碼與 manifest/lockfile 均與 #159 相同，沿用該次 ci:static、Worker 152 項、單元測試 1363 通過／1 pending 及打包驗證結果。GitHub 實際分組待設定合併後確認。

相關 PR：#154、#160；Node 型別 #140 維持延後處置。
